### PR TITLE
Fixed issue with retrieving jaeger pod name

### DIFF
--- a/tools/jaeger
+++ b/tools/jaeger
@@ -1,3 +1,3 @@
-export JAEGER_POD=$(kubectl get pods  -l "jaeger-component=query" -o jsonpath="{.items[0].metadata.name}")
+export JAEGER_POD=$(kubectl get pods -n jaeger -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}" | grep jaeger-query)
 `sleep 1 && open http://localhost:16686/` &
-kubectl port-forward $JAEGER_POD 16686 
+kubectl port-forward  -n jaeger $JAEGER_POD 16686 


### PR DESCRIPTION
Previously calling tools/jaeger would result in an error.