### PR TITLE
Add git branch option for flux install

### DIFF
--- a/cluster/azure/aks/variables.tf
+++ b/cluster/azure/aks/variables.tf
@@ -36,7 +36,7 @@ variable "agent_vm_size" {
 
 variable "kubernetes_version" {
     type = "string"
-    default = "1.12.4"
+    default = "1.12.5"
 }
 
 variable "admin_user" {

--- a/cluster/common/flux/deploy_flux.sh
+++ b/cluster/common/flux/deploy_flux.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
-while getopts f:g:k:c option 
+while getopts :b:f:g:k: option 
 do 
  case "${option}" in 
+ b) GITOPS_URL_BRANCH=${OPTARG};;
  f) FLUX_REPO_URL=${OPTARG};; 
  g) GITOPS_URL=${OPTARG};; 
  k) GITOPS_SSH_KEY=${OPTARG};; 
@@ -40,7 +41,7 @@ fi
 #   git url: where flux monitors for manifests
 #   git ssh secret: kubernetes secret object for flux to read/write access to manifests repo
 echo "generating flux manifests with helm template"
-if ! helm template . --name $RELEASE_NAME --namespace $KUBE_NAMESPACE --values values.yaml --output-dir ./$FLUX_MANIFESTS --set git.url=$GITOPS_URL --set git.secretName=$KUBE_SECRET_NAME --set ssh.known_hosts="$GIT_KNOWN_HOSTS"; then
+if ! helm template . --name $RELEASE_NAME --namespace $KUBE_NAMESPACE --values values.yaml --output-dir ./$FLUX_MANIFESTS --set git.url=$GITOPS_URL --set git.branch=$GITOPS_URL_BRANCH --set git.secretName=$KUBE_SECRET_NAME --set ssh.known_hosts="$GIT_KNOWN_HOSTS"; then
     echo "ERROR: failed to helm template"
     exit 1
 fi

--- a/cluster/common/flux/main.tf
+++ b/cluster/common/flux/main.tf
@@ -6,7 +6,7 @@ provider "null" {
 resource "null_resource" "deploy_flux" {
   count  = "${var.enable_flux ? 1 : 0}"
   provisioner "local-exec" {
-    command = "echo 'Need to use this var so terraform waits for kubeconfig ' ${var.kubeconfig_complete};KUBECONFIG=${var.output_directory}/${var.kubeconfig_filename} ${path.module}/deploy_flux.sh -f ${var.flux_repo_url} -g ${var.gitops_url} -k ${var.gitops_ssh_key}"
+    command = "echo 'Need to use this var so terraform waits for kubeconfig ' ${var.kubeconfig_complete};KUBECONFIG=${var.output_directory}/${var.kubeconfig_filename} ${path.module}/deploy_flux.sh -b ${var.gitops_url_branch} -f ${var.flux_repo_url} -g ${var.gitops_url} -k ${var.gitops_ssh_key}"
   }
 
   triggers {

--- a/cluster/common/flux/variables.tf
+++ b/cluster/common/flux/variables.tf
@@ -4,10 +4,15 @@ variable "flux_repo_url" {
   default = "https://github.com/weaveworks/flux.git"
 }
 
-# URL of git repo with Kubernetes manifests including services which runs in the cluster
-# flux monitors this repo for Kubernetes manifest additions/changes preriodiaclly and apply them in the cluster
 variable "gitops_url" {
+  description = "ssh git clone repository URL with Kubernetes manifests including services which runs in the cluster. Flux monitors this repo for Kubernetes manifest additions/changes preriodiaclly and apply them in the cluster."
   type = "string"
+}
+
+variable "gitops_url_branch" {
+  description = "Git branch associated with the gitops_url where flux checks for the raw kubernetes yaml files to deploy to the cluster."
+  type = "string"
+  default = "master"
 }
 
 # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity


### PR DESCRIPTION
Allows someone to specify the `gitops_url_branch` variable for the flux module so flux will try to sync from the branch of the `gitops_url` location.

Bumps the default k8s version to 1.12.5

Fixes #104 