### PR TITLE
Resource group Terraform consistency

### DIFF
--- a/cluster/azure/README.md
+++ b/cluster/azure/README.md
@@ -23,7 +23,6 @@ With this new environment created, edit `environments/azure/<cluster name>/terra
 - `resource_group_name`: Name of the resource group for the cluster
 - `resource_group_location`: Azure region the resource group should be created in.
 - `cluster_name`: Name of the Kubernetes cluster
-- `cluster_location`:  Azure region that the cluster should be placed in.
 - `agent_vm_count`: The number of agents VMs in the the node pool.
 - `dns_prefix`: DNS name for accessing the cluster from the internet.
 - `service_principal_id`: The id of the service principal used by the AKS cluster.  This is generated using the Azure CLI (see [Creating Service Principal](#creating-service-principal) for details).

--- a/cluster/azure/aks/main.tf
+++ b/cluster/azure/aks/main.tf
@@ -1,10 +1,16 @@
 module "azure-provider" {
     source = "../provider"
 }
+
+resource "azurerm_resource_group" "cluster" {
+  name     = "${var.resource_group_name}"
+  location = "${var.resource_group_location}"
+}
+
 resource "azurerm_kubernetes_cluster" "cluster" {
   name                = "${var.cluster_name}"
-  location            = "${var.cluster_location}"
-  resource_group_name = "${var.resource_group_name}"
+  location            = "${azurerm_resource_group.cluster.location}"
+  resource_group_name = "${azurerm_resource_group.cluster.name}"
   dns_prefix          = "${var.dns_prefix}"
   kubernetes_version  = "${var.kubernetes_version}"
 

--- a/cluster/azure/aks/variables.tf
+++ b/cluster/azure/aks/variables.tf
@@ -1,4 +1,6 @@
-
+variable "resource_group_location" {
+    type = "string"
+}
 variable "resource_group_name" {
     type = "string"
 }
@@ -6,10 +8,6 @@ variable "resource_group_name" {
 variable "cluster_name" {
     type = "string"
     default = "bedrockaks"
-}
-
-variable "cluster_location" {
-    type = "string"
 }
 
 variable "dns_prefix" {
@@ -36,7 +34,7 @@ variable "agent_vm_size" {
 
 variable "kubernetes_version" {
     type = "string"
-    default = "1.12.4"
+    default = "1.12.5"
 }
 
 variable "admin_user" {

--- a/cluster/azure/provider/main.tf
+++ b/cluster/azure/provider/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-    version = "=1.21.0"
+    version = "~>1.21.0"
 }
 
 provider "null" {

--- a/cluster/common/flux/deploy_flux.sh
+++ b/cluster/common/flux/deploy_flux.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
-while getopts f:g:k:c option 
+while getopts :b:f:g:k: option 
 do 
  case "${option}" in 
+ b) GITOPS_URL_BRANCH=${OPTARG};;
  f) FLUX_REPO_URL=${OPTARG};; 
  g) GITOPS_URL=${OPTARG};; 
  k) GITOPS_SSH_KEY=${OPTARG};; 
@@ -40,7 +41,7 @@ fi
 #   git url: where flux monitors for manifests
 #   git ssh secret: kubernetes secret object for flux to read/write access to manifests repo
 echo "generating flux manifests with helm template"
-if ! helm template . --name $RELEASE_NAME --namespace $KUBE_NAMESPACE --values values.yaml --output-dir ./$FLUX_MANIFESTS --set git.url=$GITOPS_URL --set git.secretName=$KUBE_SECRET_NAME --set ssh.known_hosts="$GIT_KNOWN_HOSTS"; then
+if ! helm template . --name $RELEASE_NAME --namespace $KUBE_NAMESPACE --values values.yaml --output-dir ./$FLUX_MANIFESTS --set git.url=$GITOPS_URL --set git.branch=$GITOPS_URL_BRANCH --set git.secretName=$KUBE_SECRET_NAME --set ssh.known_hosts="$GIT_KNOWN_HOSTS"; then
     echo "ERROR: failed to helm template"
     exit 1
 fi

--- a/cluster/common/flux/main.tf
+++ b/cluster/common/flux/main.tf
@@ -6,7 +6,7 @@ provider "null" {
 resource "null_resource" "deploy_flux" {
   count  = "${var.enable_flux ? 1 : 0}"
   provisioner "local-exec" {
-    command = "echo 'Need to use this var so terraform waits for kubeconfig ' ${var.kubeconfig_complete};KUBECONFIG=${var.output_directory}/${var.kubeconfig_filename} ${path.module}/deploy_flux.sh -f ${var.flux_repo_url} -g ${var.gitops_url} -k ${var.gitops_ssh_key}"
+    command = "echo 'Need to use this var so terraform waits for kubeconfig ' ${var.kubeconfig_complete};KUBECONFIG=${var.output_directory}/${var.kubeconfig_filename} ${path.module}/deploy_flux.sh -b ${var.gitops_url_branch} -f ${var.flux_repo_url} -g ${var.gitops_url} -k ${var.gitops_ssh_key}"
   }
 
   triggers {

--- a/cluster/common/flux/variables.tf
+++ b/cluster/common/flux/variables.tf
@@ -4,10 +4,15 @@ variable "flux_repo_url" {
   default = "https://github.com/weaveworks/flux.git"
 }
 
-# URL of git repo with Kubernetes manifests including services which runs in the cluster
-# flux monitors this repo for Kubernetes manifest additions/changes preriodiaclly and apply them in the cluster
 variable "gitops_url" {
+  description = "ssh git clone repository URL with Kubernetes manifests including services which runs in the cluster. Flux monitors this repo for Kubernetes manifest additions/changes preriodiaclly and apply them in the cluster."
   type = "string"
+}
+
+variable "gitops_url_branch" {
+  description = "Git branch associated with the gitops_url where flux checks for the raw kubernetes yaml files to deploy to the cluster."
+  type = "string"
+  default = "master"
 }
 
 # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -3,25 +3,11 @@
 #    }
 # }
 
-module "provider" {
-    source = "../../azure/provider"
-}
-
-resource "azurerm_resource_group" "clusterrg" {
-  name     = "${var.resource_group_name}"
-  location = "${var.resource_group_location}"
-}
-
-resource "azurerm_resource_group" "vnetrg" {
-  name     = "${var.cluster_name}-vnetrg"
-  location = "${var.resource_group_location}"
-}
-
 module "vnet" {
     source = "../../azure/vnet"
 
-    resource_group_name = "${azurerm_resource_group.vnetrg.name}"
-    location            = "${azurerm_resource_group.vnetrg.location}"
+    resource_group_name = "myaksvnet"
+    location            = "${var.resource_group_location}"
     subnet_names        = ["${var.cluster_name}-aks-subnet"]
 
     tags = {
@@ -32,9 +18,9 @@ module "vnet" {
 module "aks" {
     source = "../../azure/aks"
 
-    resource_group_name       = "${azurerm_resource_group.clusterrg.name}"
+    resource_group_location   = "${var.resource_group_location}"
+    resource_group_name       = "${var.resource_group_name}"
     cluster_name              = "${var.cluster_name}"
-    cluster_location          = "${azurerm_resource_group.clusterrg.location}"
     agent_vm_count            = "${var.agent_vm_count}"
     dns_prefix                = "${var.dns_prefix}"
     vnet_subnet_id            = "${module.vnet.vnet_subnet_ids[0]}"
@@ -46,6 +32,7 @@ module "aks" {
 
 module "flux" {
     source = "../../common/flux"
+
     gitops_url                = "${var.gitops_url}"
     gitops_ssh_key            = "${var.gitops_ssh_key}"
     flux_recreate             = ""

--- a/cluster/environments/azure-simple/terraform.tfvars
+++ b/cluster/environments/azure-simple/terraform.tfvars
@@ -1,7 +1,6 @@
 resource_group_name="resource-group-name"
 resource_group_location="westus2"
 cluster_name="cluster-name"
-cluster_location="westus2"
 agent_vm_count = "3"
 dns_prefix="dns-prefix"
 service_principal_id = "client-id"

--- a/cluster/environments/azure-simple/variables.tf
+++ b/cluster/environments/azure-simple/variables.tf
@@ -10,10 +10,6 @@ variable "cluster_name" {
     type = "string"
 }
 
-variable "cluster_location" {
-    type = "string"
-}
-
 variable "agent_vm_count" {
     type = "string"
     default = "3"


### PR DESCRIPTION
Keeps the resource group creation structure consistent across all modules under `/azure` and simplifies the code needed for the `azure-simple` example.

Merge this after PR #104 