### PR TITLE
Azure Traffic Manager implementation with multiple aks clusters

### DIFF
--- a/cluster/azure/README.md
+++ b/cluster/azure/README.md
@@ -66,16 +66,27 @@ in the cluster to start a [GitOps](https://www.weave.works/blog/gitops-operation
 
 Once your cluster has been created the credentials for the cluster will be placed in the specified `output_directory` which defaults to `./output`. 
 
-You can copy this to your `~/.kube/config` by executing:
+With the default kube config file name, you can copy this to your `~/.kube/config` by executing:
 
 ```bash
 $ KUBECONFIG=./output/bedrock_kube_config:~/.kube/config kubectl config view --flatten > merged-config && mv merged-config ~/.kube/config
 ```
 
-or directly use the kube_config file with:
+In a multi cluster deployment environment, you can copy this to your `~/.kube/config` by replacing `location` and `clustername` in the following command for each cluster:
+```
+$ KUBECONFIG=./output/<location>-<clustername>_kube_config:~/.kube/config kubectl config view --flatten > merged-config && mv merged-config ~/.kube/config
+```
+
+or directly use the kube_config file with default output file name:
 
 ```
 $ KUBECONFIG=./output/bedrock_kube_config kubectl get po --namespace=flux` 
+```
+
+or directly use the kube_config file by replacing `location` and `clustername` in the following command in multi cluster deployment:
+
+```
+$ KUBECONFIG=./output/<location>-<clustername>_kube_config kubectl get po --namespace=flux` 
 ```
 
 ### Creating Service Principal

--- a/cluster/azure/tm-endpoint-ip/main.tf
+++ b/cluster/azure/tm-endpoint-ip/main.tf
@@ -1,0 +1,32 @@
+resource "azurerm_public_ip" "pip" {
+  name                = "${var.public_ip_name}-ip"
+  location            = "${var.resource_location}"
+  resource_group_name = "${var.resource_group_name}"
+  allocation_method   = "Static"
+  domain_name_label   = "${var.public_ip_name}-dns"
+  tags                = "${var.tags}"
+}
+
+resource "azurerm_traffic_manager_endpoint" "endpoint" {
+  name                = "${var.endpoint_name}-ep"
+  resource_group_name = "${var.traffic_manager_resource_group_name}"
+  profile_name        = "${var.traffic_manager_profile_name}"
+  target              = "${var.endpoint_name}-dns"
+  target_resource_id  = "${azurerm_public_ip.pip.id}"
+  type                = "azureEndpoints"
+  weight              = 1
+}
+
+resource "null_resource" "ip_address" {
+  count = "${var.ipaddress_to_disk ? 1 : 0}"
+
+  provisioner "local-exec" {
+    command = "if [ ! -e ${var.output_directory} ]; then mkdir -p ${var.output_directory}; fi && echo ${azurerm_public_ip.pip.ip_address} > ${var.output_directory}/${var.ip_address_filename}"
+  }
+
+  triggers {
+    ipaddress_to_disk  = "${var.ipaddress_to_disk}"
+  }
+
+  depends_on = ["azurerm_public_ip.pip"]
+}

--- a/cluster/azure/tm-endpoint-ip/main.tf
+++ b/cluster/azure/tm-endpoint-ip/main.tf
@@ -21,7 +21,7 @@ resource "null_resource" "ip_address" {
   count = "${var.ipaddress_to_disk ? 1 : 0}"
 
   provisioner "local-exec" {
-    command = "if [ ! -e ${var.output_directory} ]; then mkdir -p ${var.output_directory}; fi && echo ${azurerm_public_ip.pip.ip_address} > ${var.output_directory}/${var.ip_address_filename}"
+    command = "if [ ! -e ${var.output_directory} ]; then mkdir -p ${var.output_directory}; fi && echo ${azurerm_public_ip.pip.ip_address} > ${var.output_directory}/${var.ip_address_out_filename}"
   }
 
   triggers {

--- a/cluster/azure/tm-endpoint-ip/outputs.tf
+++ b/cluster/azure/tm-endpoint-ip/outputs.tf
@@ -1,0 +1,3 @@
+output "public_ip" {
+  value = "${azurerm_public_ip.pip.ip_address}"
+}

--- a/cluster/azure/tm-endpoint-ip/variables.tf
+++ b/cluster/azure/tm-endpoint-ip/variables.tf
@@ -1,0 +1,49 @@
+variable "traffic_manager_profile_name" {
+  type = "string"
+}
+
+variable "traffic_manager_resource_group_name" {
+  type = "string"
+}
+
+variable "public_ip_name" {
+  type = "string"
+}
+
+variable "endpoint_name" {
+  type = "string"
+}
+
+variable "resource_group_name" {
+  type = "string"
+}
+
+variable "resource_location" {
+  type = "string"
+}
+
+variable "ip_address_filename" {
+  type    = "string"
+  default = "bedrock_public_ip_address"
+}
+
+variable "ipaddress_to_disk" {
+  description = "This disables or enables the ip address output file from being written to disk."
+  type        = "string"
+  default     = "true"
+}
+
+variable "output_directory" {
+  type    = "string"
+  default = "./output"
+}
+
+variable "tags" {
+  description = "The tags to associate with the public ip address."
+  type        = "map"
+
+  default = {
+    tag1 = ""
+    tag2 = ""
+  }
+}

--- a/cluster/azure/tm-endpoint-ip/variables.tf
+++ b/cluster/azure/tm-endpoint-ip/variables.tf
@@ -22,7 +22,7 @@ variable "resource_location" {
   type = "string"
 }
 
-variable "ip_address_filename" {
+variable "ip_address_out_filename" {
   type    = "string"
   default = "bedrock_public_ip_address"
 }
@@ -30,7 +30,7 @@ variable "ip_address_filename" {
 variable "ipaddress_to_disk" {
   description = "This disables or enables the ip address output file from being written to disk."
   type        = "string"
-  default     = "true"
+  default     = "false"
 }
 
 variable "output_directory" {

--- a/cluster/azure/tm-profile/main.tf
+++ b/cluster/azure/tm-profile/main.tf
@@ -1,0 +1,24 @@
+resource "azurerm_resource_group" "tmrg" {
+  name     = "${var.resource_group_name}"
+  location = "${var.resource_group_location}"
+}
+
+# Creates Azure Traffic Manager Profile
+resource "azurerm_traffic_manager_profile" "profile" {
+  name                   = "${var.traffic_manager_profile_name}"
+  resource_group_name    = "${azurerm_resource_group.tmrg.name}"
+  traffic_routing_method = "Weighted"
+
+  dns_config {
+    relative_name = "${var.traffic_manager_dns_name}"
+    ttl           = 30
+  }
+
+  monitor_config {
+    protocol = "http"
+    port     = 80
+    path     = "/"
+  }
+
+  tags = "${var.tags}"
+}

--- a/cluster/azure/tm-profile/main.tf
+++ b/cluster/azure/tm-profile/main.tf
@@ -15,8 +15,8 @@ resource "azurerm_traffic_manager_profile" "profile" {
   }
 
   monitor_config {
-    protocol = "http"
-    port     = 80
+    protocol = "${var.traffic_manager_monitor_protocol}"
+    port     = "${var.traffic_manager_monitor_port}"
     path     = "/"
   }
 

--- a/cluster/azure/tm-profile/variables.tf
+++ b/cluster/azure/tm-profile/variables.tf
@@ -14,11 +14,15 @@ variable "resource_group_location"{
   type="string"
 }
 
-# variable "public_ips" {
-#   description = "A list of public ips"
-#   type        = "list"
-#   default     = ["ip1", "ip2"]
-# }
+variable "traffic_manager_monitor_protocol"{
+  type="string"
+  default="http"
+}
+
+variable "traffic_manager_monitor_port"{
+  type="string"
+  default="80"
+}
 
 variable "tags" {
   description = "The tags to associate with the traffic maanger."

--- a/cluster/azure/tm-profile/variables.tf
+++ b/cluster/azure/tm-profile/variables.tf
@@ -1,0 +1,31 @@
+variable "traffic_manager_profile_name" {
+  type = "string"
+}
+
+variable "traffic_manager_dns_name" {
+  type = "string"
+}
+
+variable "resource_group_name" {
+  type = "string"
+}
+
+variable "resource_group_location"{
+  type="string"
+}
+
+# variable "public_ips" {
+#   description = "A list of public ips"
+#   type        = "list"
+#   default     = ["ip1", "ip2"]
+# }
+
+variable "tags" {
+  description = "The tags to associate with the traffic maanger."
+  type        = "map"
+
+  default = {
+    tag1 = ""
+    tag2 = ""
+  }
+}

--- a/cluster/azure/vnet/main.tf
+++ b/cluster/azure/vnet/main.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "vnet" {
   name     = "${var.resource_group_name}"
-  location = "${var.location}"
+  location = "${var.resource_group_location}"
 }
 
 resource "azurerm_virtual_network" "vnet" {

--- a/cluster/azure/vnet/variables.tf
+++ b/cluster/azure/vnet/variables.tf
@@ -10,7 +10,6 @@ variable "resource_group_name" {
 
 variable "resource_group_location" {
   description = "Default resource group location that the resource group will be created in. The full list of Azure regions can be found at https://azure.microsoft.com/regions"
-  default     = "westus2"
 }
 
 variable "location" {

--- a/cluster/azure/vnet/variables.tf
+++ b/cluster/azure/vnet/variables.tf
@@ -8,6 +8,11 @@ variable "resource_group_name" {
   default     = "myapp-rg"
 }
 
+variable "resource_group_location" {
+  description = "Default resource group location that the resource group will be created in. The full list of Azure regions can be found at https://azure.microsoft.com/regions"
+  default     = "westus2"
+}
+
 variable "location" {
   description = "The location/region where the core network will be created. The full list of Azure regions can be found at https://azure.microsoft.com/regions"
 }

--- a/cluster/common/flux/deploy_flux.sh
+++ b/cluster/common/flux/deploy_flux.sh
@@ -1,27 +1,35 @@
 #!/bin/sh
-while getopts :b:f:g:k: option 
+while getopts :b:f:g:k:d: option 
 do 
  case "${option}" in 
  b) GITOPS_URL_BRANCH=${OPTARG};;
  f) FLUX_REPO_URL=${OPTARG};; 
  g) GITOPS_URL=${OPTARG};; 
  k) GITOPS_SSH_KEY=${OPTARG};; 
+ d) REPO_ROOT_DIR=${OPTARG};;
  esac
 done 
 
 KUBE_SECRET_NAME="flux-ssh"
 RELEASE_NAME="flux"
 KUBE_NAMESPACE="flux"
-REPO_DIR="flux"
+REPO_DIR="$REPO_ROOT_DIR/flux"
 FLUX_CHART_DIR="flux/chart/flux"
 FLUX_MANIFESTS="manifests"
 
-GIT_KNOWN_HOSTS="`ssh-keyscan github.com gitlab.com bitbucket.org ssh.dev.azure.com`"
+echo "flux repo root directory: $REPO_ROOT_DIR"
 
-echo "known_hosts $GIT_KNOWN_HOSTS"
+rm -rf $REPO_ROOT_DIR
+
+echo "creating $REPO_ROOT_DIR directory"
+if ! mkdir $REPO_ROOT_DIR; then
+    echo "ERROR: failed to create directory $REPO_ROOT_DIR"
+    exit 1
+fi
+
+cd $REPO_ROOT_DIR
 
 echo "cloning $FLUX_REPO_URL"
-rm -rf $REPO_DIR
 
 if ! git clone $FLUX_REPO_URL; then
     echo "ERROR: failed to clone $FLUX_REPO_URL"
@@ -41,12 +49,13 @@ fi
 #   git url: where flux monitors for manifests
 #   git ssh secret: kubernetes secret object for flux to read/write access to manifests repo
 echo "generating flux manifests with helm template"
-if ! helm template . --name $RELEASE_NAME --namespace $KUBE_NAMESPACE --values values.yaml --output-dir ./$FLUX_MANIFESTS --set git.url=$GITOPS_URL --set git.branch=$GITOPS_URL_BRANCH --set git.secretName=$KUBE_SECRET_NAME --set ssh.known_hosts="$GIT_KNOWN_HOSTS"; then
+if ! helm template . --name $RELEASE_NAME --namespace $KUBE_NAMESPACE --values values.yaml --output-dir ./$FLUX_MANIFESTS --set git.url=$GITOPS_URL --set git.branch=$GITOPS_URL_BRANCH --set git.secretName=$KUBE_SECRET_NAME; then
     echo "ERROR: failed to helm template"
     exit 1
 fi
 
-cd ../../../
+# back to the roor dir
+cd ../../../../
 
 echo "creating kubernetes namespace $KUBE_NAMESPACE"
 if ! kubectl create namespace $KUBE_NAMESPACE; then
@@ -58,7 +67,7 @@ echo "creating kubernetes secret $KUBE_SECRET_NAME from key file path $GITOPS_SS
 kubectl create secret generic $KUBE_SECRET_NAME --from-file=identity=$GITOPS_SSH_KEY -n $KUBE_NAMESPACE
 
 echo "Applying flux deployment"
-if ! kubectl apply -f  $FLUX_CHART_DIR/$FLUX_MANIFESTS/flux/templates -n $KUBE_NAMESPACE; then
+if ! kubectl apply -f  $REPO_ROOT_DIR/$FLUX_CHART_DIR/$FLUX_MANIFESTS/flux/templates -n $KUBE_NAMESPACE; then
     echo "ERROR: failed to apply flux deployment"
     exit 1
 fi

--- a/cluster/common/flux/deploy_flux.sh
+++ b/cluster/common/flux/deploy_flux.sh
@@ -13,8 +13,9 @@ done
 KUBE_SECRET_NAME="flux-ssh"
 RELEASE_NAME="flux"
 KUBE_NAMESPACE="flux"
-REPO_DIR="$REPO_ROOT_DIR/flux"
-FLUX_CHART_DIR="flux/chart/flux"
+CLONE_DIR="flux"
+REPO_DIR="$REPO_ROOT_DIR/$CLONE_DIR"
+FLUX_CHART_DIR="chart/flux"
 FLUX_MANIFESTS="manifests"
 
 echo "flux repo root directory: $REPO_ROOT_DIR"
@@ -36,7 +37,7 @@ if ! git clone $FLUX_REPO_URL; then
     exit 1
 fi
 
-cd $FLUX_CHART_DIR
+cd $CLONE_DIR/$FLUX_CHART_DIR
 
 echo "creating $FLUX_MANIFESTS directory"
 if ! mkdir $FLUX_MANIFESTS; then
@@ -67,7 +68,7 @@ echo "creating kubernetes secret $KUBE_SECRET_NAME from key file path $GITOPS_SS
 kubectl create secret generic $KUBE_SECRET_NAME --from-file=identity=$GITOPS_SSH_KEY -n $KUBE_NAMESPACE
 
 echo "Applying flux deployment"
-if ! kubectl apply -f  $REPO_ROOT_DIR/$FLUX_CHART_DIR/$FLUX_MANIFESTS/flux/templates -n $KUBE_NAMESPACE; then
+if ! kubectl apply -f  $REPO_DIR/$FLUX_CHART_DIR/$FLUX_MANIFESTS/flux/templates -n $KUBE_NAMESPACE; then
     echo "ERROR: failed to apply flux deployment"
     exit 1
 fi

--- a/cluster/common/flux/main.tf
+++ b/cluster/common/flux/main.tf
@@ -6,7 +6,7 @@ provider "null" {
 resource "null_resource" "deploy_flux" {
   count  = "${var.enable_flux ? 1 : 0}"
   provisioner "local-exec" {
-    command = "echo 'Need to use this var so terraform waits for kubeconfig ' ${var.kubeconfig_complete};KUBECONFIG=${var.output_directory}/${var.kubeconfig_filename} ${path.module}/deploy_flux.sh -b ${var.gitops_url_branch} -f ${var.flux_repo_url} -g ${var.gitops_url} -k ${var.gitops_ssh_key}"
+    command = "echo 'Need to use this var so terraform waits for kubeconfig ' ${var.kubeconfig_complete};KUBECONFIG=${var.output_directory}/${var.kubeconfig_filename} ${path.module}/deploy_flux.sh -b ${var.gitops_url_branch} -f ${var.flux_repo_url} -g ${var.gitops_url} -k ${var.gitops_ssh_key} -d ${var.flux_clone_dir}"
   }
 
   triggers {

--- a/cluster/common/flux/variables.tf
+++ b/cluster/common/flux/variables.tf
@@ -50,3 +50,8 @@ variable "kubeconfig_complete" {
     description = "Allows flux to wait for the kubeconfig completion write to disk. Workaround for the fact that modules themselves cannot have dependencies."
     type = "string"
 }
+
+variable "flux_clone_dir" {
+    description = "Name of the directory to clone flux repo and deploy in the cluster."
+    type = "string"
+}

--- a/cluster/environments/azure-multiple-clusters/aks-eastus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus-variables.tf
@@ -1,0 +1,8 @@
+variable "east_resource_group_name" {
+  type = "string"
+}
+
+variable "east_resource_group_location" {
+  type    = "string"
+  default = "eastus2"
+}

--- a/cluster/environments/azure-multiple-clusters/aks-eastus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus-variables.tf
@@ -4,5 +4,4 @@ variable "east_resource_group_name" {
 
 variable "east_resource_group_location" {
   type    = "string"
-  default = "eastus2"
 }

--- a/cluster/environments/azure-multiple-clusters/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus.tf
@@ -5,18 +5,21 @@ resource "azurerm_resource_group" "eastrg" {
 
 # local variable with cluster and location specific
 locals {
-  east_flux_clone_dir      = "${azurerm_resource_group.eastrg.location}-${var.cluster_name}-flux"
-  east_kubeconfig_filename = "${azurerm_resource_group.eastrg.location}_${var.cluster_name}_kube_config"
-  east_ip_address_filename = "${azurerm_resource_group.eastrg.location}_${var.cluster_name}_ip_address"
+  east_rg_name                 = "${azurerm_resource_group.eastrg.name}"
+  east_rg_location             = "${azurerm_resource_group.eastrg.location}"
+  east_prefix                  = "${local.east_rg_location}-${var.cluster_name}"
+  east_flux_clone_dir          = "${local.east_prefix}-flux"
+  east_kubeconfig_filename     = "${local.east_prefix}_kube_config"
+  east_ip_address_out_filename = "${local.east_prefix}_ip_address"
 }
 
 # Creates vnet
 module "east_vnet" {
   source = "../../azure/vnet"
 
-  resource_group_name     = "${azurerm_resource_group.eastrg.name}"
-  resource_group_location = "${azurerm_resource_group.eastrg.location}"
-  location                = "${azurerm_resource_group.eastrg.location}"
+  resource_group_name     = "${local.east_rg_name }"
+  resource_group_location = "${local.east_rg_location}"
+  location                = "${local.east_rg_location}"
   subnet_names            = ["${var.cluster_name}-aks-subnet"]
 
   tags = {
@@ -28,8 +31,8 @@ module "east_vnet" {
 module "east_aks" {
   source = "../../azure/aks"
 
-  resource_group_name      = "${azurerm_resource_group.eastrg.name}"
-  resource_group_location  = "${azurerm_resource_group.eastrg.location}"
+  resource_group_name      = "${local.east_rg_name }"
+  resource_group_location  = "${local.east_rg_location}"
   cluster_name             = "${var.cluster_name}"
   agent_vm_count           = "${var.agent_vm_count}"
   dns_prefix               = "${var.dns_prefix}"
@@ -57,13 +60,13 @@ module "east_flux" {
 module "east_tm_endpoint" {
   source = "../../azure/tm-endpoint-ip"
 
-  resource_group_name                 = "${azurerm_resource_group.eastrg.name}"
-  resource_location                   = "${azurerm_resource_group.eastrg.location}"
+  resource_group_name                 = "${local.east_rg_name }"
+  resource_location                   = "${local.east_rg_location}"
   traffic_manager_resource_group_name = "${var.traffic_manager_resource_group_name}"
   traffic_manager_profile_name        = "${var.traffic_manager_profile_name}"
-  endpoint_name                       = "${azurerm_resource_group.eastrg.location}-${var.cluster_name}"
+  endpoint_name                       = "${local.east_rg_location}-${var.cluster_name}"
   public_ip_name                      = "${var.cluster_name}"
-  ip_address_filename                 = "${local.east_ip_address_filename}"
+  ip_address_out_filename             = "${local.east_ip_address_out_filename}"
 
   tags = {
     environment = "azure-multiple-clusters - ${var.cluster_name} - public ip"

--- a/cluster/environments/azure-multiple-clusters/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus.tf
@@ -1,0 +1,79 @@
+resource "azurerm_resource_group" "eastrg" {
+  name     = "${var.east_resource_group_name}"
+  location = "${var.east_resource_group_location}"
+}
+
+# local variable with cluster and location specific
+locals {
+  east_flux_clone_dir      = "${azurerm_resource_group.eastrg.location}-${var.cluster_name}-flux"
+  east_kubeconfig_filename = "${azurerm_resource_group.eastrg.location}_${var.cluster_name}_kube_config"
+  east_ip_address_filename = "${azurerm_resource_group.eastrg.location}_${var.cluster_name}_ip_address"
+}
+
+# Creates vnet
+module "east_vnet" {
+  source = "../../azure/vnet"
+
+  resource_group_name     = "${azurerm_resource_group.eastrg.name}"
+  resource_group_location = "${azurerm_resource_group.eastrg.location}"
+  location                = "${azurerm_resource_group.eastrg.location}"
+  subnet_names            = ["${var.cluster_name}-aks-subnet"]
+
+  tags = {
+    environment = "azure-multiple-clusters"
+  }
+}
+
+# Creates aks cluster
+module "east_aks" {
+  source = "../../azure/aks"
+
+  resource_group_name      = "${azurerm_resource_group.eastrg.name}"
+  resource_group_location  = "${azurerm_resource_group.eastrg.location}"
+  cluster_name             = "${var.cluster_name}"
+  agent_vm_count           = "${var.agent_vm_count}"
+  dns_prefix               = "${var.dns_prefix}"
+  vnet_subnet_id           = "${module.east_vnet.vnet_subnet_ids[0]}"
+  ssh_public_key           = "${var.ssh_public_key}"
+  service_principal_id     = "${var.service_principal_id}"
+  service_principal_secret = "${var.service_principal_secret}"
+  kubeconfig_recreate      = ""
+  kubeconfig_filename      = "${local.east_kubeconfig_filename}"
+}
+
+# Deploys flux in aks cluster
+module "east_flux" {
+  source = "../../common/flux"
+
+  gitops_url          = "${var.gitops_url}"
+  gitops_ssh_key      = "${var.gitops_ssh_key}"
+  flux_recreate       = ""
+  kubeconfig_complete = "${module.east_aks.kubeconfig_done}"
+  kubeconfig_filename = "${local.east_kubeconfig_filename}"
+  flux_clone_dir      = "${local.east_flux_clone_dir}"
+}
+
+# create a static public ip and associate with traffic manger endpoint 
+module "east_tm_endpoint" {
+  source = "../../azure/tm-endpoint-ip"
+
+  resource_group_name                 = "${azurerm_resource_group.eastrg.name}"
+  resource_location                   = "${azurerm_resource_group.eastrg.location}"
+  traffic_manager_resource_group_name = "${var.traffic_manager_resource_group_name}"
+  traffic_manager_profile_name        = "${var.traffic_manager_profile_name}"
+  endpoint_name                       = "${azurerm_resource_group.eastrg.location}-${var.cluster_name}"
+  public_ip_name                      = "${var.cluster_name}"
+  ip_address_filename                 = "${local.east_ip_address_filename}"
+
+  tags = {
+    environment = "azure-multiple-clusters - ${var.cluster_name} - public ip"
+  }
+}
+
+# Create a role assignment with Contributor role for AKS client service principal object 
+#   to join vnet/subnet/ip for load balancer/ingress controller
+resource "azurerm_role_assignment" "east_spra" {
+  principal_id         = "${data.azuread_service_principal.sp.id}"
+  role_definition_name = "${var.aks_client_role_assignment_role}"
+  scope                = "${azurerm_resource_group.eastrg.id}"
+}

--- a/cluster/environments/azure-multiple-clusters/aks-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-variables.tf
@@ -1,0 +1,37 @@
+variable "cluster_name" {
+    type = "string"
+}
+
+variable "agent_vm_count" {
+    type = "string"
+    default = "3"
+}
+
+variable "dns_prefix" {
+    type = "string"
+}
+
+variable "ssh_public_key" {
+    type = "string"
+}
+
+variable "service_principal_id" {
+    type = "string"
+}
+
+variable "service_principal_secret" {
+    type = "string"
+}
+
+variable "gitops_url" {
+  type = "string"
+}
+
+variable "gitops_ssh_key" {
+  type    = "string"
+}
+
+variable "aks_client_role_assignment_role" {
+  type    = "string"
+  default = "Contributor"
+}

--- a/cluster/environments/azure-multiple-clusters/aks-westus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus-variables.tf
@@ -1,0 +1,8 @@
+variable "west_resource_group_name" {
+  type = "string"
+}
+
+variable "west_resource_group_location" {
+  type    = "string"
+  default = "westus2"
+}

--- a/cluster/environments/azure-multiple-clusters/aks-westus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus-variables.tf
@@ -4,5 +4,4 @@ variable "west_resource_group_name" {
 
 variable "west_resource_group_location" {
   type    = "string"
-  default = "westus2"
 }

--- a/cluster/environments/azure-multiple-clusters/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus.tf
@@ -1,0 +1,79 @@
+resource "azurerm_resource_group" "westrg" {
+  name     = "${var.west_resource_group_name}"
+  location = "${var.west_resource_group_location}"
+}
+
+# local variable with cluster and location specific
+locals {
+  west_flux_clone_dir      = "${azurerm_resource_group.westrg.location}-${var.cluster_name}-flux"
+  west_kubeconfig_filename = "${azurerm_resource_group.westrg.location}_${var.cluster_name}_kube_config"
+  west_ip_address_filename = "${azurerm_resource_group.westrg.location}_${var.cluster_name}_ip_address"
+}
+
+# Creates vnet
+module "west_vnet" {
+  source = "../../azure/vnet"
+
+  resource_group_name     = "${azurerm_resource_group.westrg.name}"
+  resource_group_location = "${azurerm_resource_group.westrg.location}"
+  location                = "${azurerm_resource_group.westrg.location}"
+  subnet_names            = ["${var.cluster_name}-aks-subnet"]
+
+  tags = {
+    environment = "azure-multiple-clusters"
+  }
+}
+
+# Creates aks cluster
+module "west_aks" {
+  source = "../../azure/aks"
+
+  resource_group_name      = "${azurerm_resource_group.westrg.name}"
+  resource_group_location  = "${azurerm_resource_group.westrg.location}"
+  cluster_name             = "${var.cluster_name}"
+  agent_vm_count           = "${var.agent_vm_count}"
+  dns_prefix               = "${var.dns_prefix}"
+  vnet_subnet_id           = "${module.west_vnet.vnet_subnet_ids[0]}"
+  ssh_public_key           = "${var.ssh_public_key}"
+  service_principal_id     = "${var.service_principal_id}"
+  service_principal_secret = "${var.service_principal_secret}"
+  kubeconfig_recreate      = ""
+  kubeconfig_filename      = "${local.west_kubeconfig_filename}"
+}
+
+# Deploys flux in aks cluster
+module "west_flux" {
+  source = "../../common/flux"
+
+  gitops_url          = "${var.gitops_url}"
+  gitops_ssh_key      = "${var.gitops_ssh_key}"
+  flux_recreate       = ""
+  kubeconfig_complete = "${module.west_aks.kubeconfig_done}"
+  kubeconfig_filename = "${local.west_kubeconfig_filename}"
+  flux_clone_dir      = "${local.west_flux_clone_dir}"
+}
+
+# create a static public ip and associate with traffic manger endpoint 
+module "west_tm_endpoint" {
+  source = "../../azure/tm-endpoint-ip"
+
+  resource_group_name                 = "${azurerm_resource_group.westrg.name}"
+  resource_location                   = "${azurerm_resource_group.westrg.location}"
+  traffic_manager_resource_group_name = "${var.traffic_manager_resource_group_name}"
+  traffic_manager_profile_name        = "${var.traffic_manager_profile_name}"
+  endpoint_name                       = "${azurerm_resource_group.westrg.location}-${var.cluster_name}"
+  public_ip_name                      = "${var.cluster_name}"
+  ip_address_filename                 = "${local.west_ip_address_filename}"
+
+  tags = {
+    environment = "azure-multiple-clusters - ${var.cluster_name} - public ip"
+  }
+}
+
+# Create a role assignment with Contributor role for AKS client service principal object 
+#   to join vnet/subnet/ip for load balancer/ingress controller
+resource "azurerm_role_assignment" "west_spra" {
+  principal_id         = "${data.azuread_service_principal.sp.id}"
+  role_definition_name = "${var.aks_client_role_assignment_role}"
+  scope                = "${azurerm_resource_group.westrg.id}"
+}

--- a/cluster/environments/azure-multiple-clusters/main.tf
+++ b/cluster/environments/azure-multiple-clusters/main.tf
@@ -1,0 +1,9 @@
+module "provider" {
+  source = "../../azure/provider"
+}
+
+# Read AKS cluster service principal (client) object to create a role assignment
+data "azuread_service_principal" "sp" {
+  application_id = "${var.service_principal_id}"
+}
+

--- a/cluster/environments/azure-multiple-clusters/terraform.tfvars
+++ b/cluster/environments/azure-multiple-clusters/terraform.tfvars
@@ -1,0 +1,19 @@
+traffic_manager_profile_name="spinprofile"
+traffic_manager_dns_name="spintmdns"
+traffic_manager_resource_group_name="global-rg"
+traffic_manager_resource_group_location="centralus"
+
+west_resource_group_name="spin-west-rg"
+west_resource_group_location="westus2"
+
+east_resource_group_name="spin-east-rg"
+east_resource_group_location="eastus2"
+
+cluster_name="spincluster"
+agent_vm_count = "3"
+dns_prefix="spindns"
+service_principal_id = "<replace me>"
+service_principal_secret = "<replace me>"
+ssh_public_key = ""
+gitops_url = ""
+gitops_ssh_key = ""

--- a/cluster/environments/azure-multiple-clusters/trafficmanager-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/trafficmanager-variables.tf
@@ -13,3 +13,13 @@ variable "traffic_manager_profile_name" {
 variable "traffic_manager_dns_name" {
   type = "string"
 }
+
+variable "traffic_manager_monitor_protocol" {
+  type    = "string"
+  default = "http"
+}
+
+variable "traffic_manager_monitor_port" {
+  type    = "string"
+  default = "80"
+}

--- a/cluster/environments/azure-multiple-clusters/trafficmanager-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/trafficmanager-variables.tf
@@ -1,0 +1,15 @@
+variable "traffic_manager_resource_group_name" {
+  type = "string"
+}
+
+variable "traffic_manager_resource_group_location" {
+  type = "string"
+}
+
+variable "traffic_manager_profile_name" {
+  type = "string"
+}
+
+variable "traffic_manager_dns_name" {
+  type = "string"
+}

--- a/cluster/environments/azure-multiple-clusters/trafficmanager.tf
+++ b/cluster/environments/azure-multiple-clusters/trafficmanager.tf
@@ -6,10 +6,12 @@ resource "azurerm_resource_group" "tmrg" {
 module "trafficmanager" {
   source = "../../azure/tm-profile"
 
-  resource_group_name          = "${azurerm_resource_group.tmrg.name}"
-  resource_group_location      = "${azurerm_resource_group.tmrg.location}"
-  traffic_manager_profile_name = "${var.traffic_manager_profile_name}"
-  traffic_manager_dns_name     = "${var.traffic_manager_dns_name}"
+  resource_group_name              = "${azurerm_resource_group.tmrg.name}"
+  resource_group_location          = "${azurerm_resource_group.tmrg.location}"
+  traffic_manager_profile_name     = "${var.traffic_manager_profile_name}"
+  traffic_manager_dns_name         = "${var.traffic_manager_dns_name}"
+  traffic_manager_monitor_protocol = "${var.traffic_manager_monitor_protocol}"
+  traffic_manager_monitor_port     = "${var.traffic_manager_monitor_port}"
 
   tags = {
     environment = "azure-multiple-clusters"

--- a/cluster/environments/azure-multiple-clusters/trafficmanager.tf
+++ b/cluster/environments/azure-multiple-clusters/trafficmanager.tf
@@ -1,0 +1,17 @@
+resource "azurerm_resource_group" "tmrg" {
+  name     = "${var.traffic_manager_resource_group_name}"
+  location = "${var.traffic_manager_resource_group_location}"
+}
+
+module "trafficmanager" {
+  source = "../../azure/tm-profile"
+
+  resource_group_name          = "${azurerm_resource_group.tmrg.name}"
+  resource_group_location      = "${azurerm_resource_group.tmrg.location}"
+  traffic_manager_profile_name = "${var.traffic_manager_profile_name}"
+  traffic_manager_dns_name     = "${var.traffic_manager_dns_name}"
+
+  tags = {
+    environment = "azure-multiple-clusters"
+  }
+}

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -4,37 +4,39 @@
 # }
 
 module "vnet" {
-    source = "../../azure/vnet"
+  source = "../../azure/vnet"
 
-    resource_group_name = "myaksvnet"
-    location            = "${var.resource_group_location}"
-    subnet_names        = ["${var.cluster_name}-aks-subnet"]
+  resource_group_name     = "${var.resource_group_name}"
+  resource_group_location = "${var.resource_group_location}"
+  location                = "${var.resource_group_location}"
+  subnet_names            = ["${var.cluster_name}-aks-subnet"]
 
-    tags = {
-      environment = "azure-simple"
-    }
+  tags = {
+    environment = "azure-simple"
+  }
 }
 
 module "aks" {
-    source = "../../azure/aks"
+  source = "../../azure/aks"
 
-    resource_group_location   = "${var.resource_group_location}"
-    resource_group_name       = "${var.resource_group_name}"
-    cluster_name              = "${var.cluster_name}"
-    agent_vm_count            = "${var.agent_vm_count}"
-    dns_prefix                = "${var.dns_prefix}"
-    vnet_subnet_id            = "${module.vnet.vnet_subnet_ids[0]}"
-    ssh_public_key            = "${var.ssh_public_key}"
-    service_principal_id      = "${var.service_principal_id}"
-    service_principal_secret  = "${var.service_principal_secret}"
-    kubeconfig_recreate       = ""
+  resource_group_location  = "${var.resource_group_location}"
+  resource_group_name      = "${var.resource_group_name}"
+  cluster_name             = "${var.cluster_name}"
+  agent_vm_count           = "${var.agent_vm_count}"
+  dns_prefix               = "${var.dns_prefix}"
+  vnet_subnet_id           = "${module.vnet.vnet_subnet_ids[0]}"
+  ssh_public_key           = "${var.ssh_public_key}"
+  service_principal_id     = "${var.service_principal_id}"
+  service_principal_secret = "${var.service_principal_secret}"
+  kubeconfig_recreate      = ""
 }
 
 module "flux" {
-    source = "../../common/flux"
+  source = "../../common/flux"
 
-    gitops_url                = "${var.gitops_url}"
-    gitops_ssh_key            = "${var.gitops_ssh_key}"
-    flux_recreate             = ""
-    kubeconfig_complete       = "${module.aks.kubeconfig_done}"
+  gitops_url          = "${var.gitops_url}"
+  gitops_ssh_key      = "${var.gitops_ssh_key}"
+  flux_recreate       = ""
+  kubeconfig_complete = "${module.aks.kubeconfig_done}"
+  flux_clone_dir      = "${var.cluster_name}-flux"
 }


### PR DESCRIPTION
* Implements Azure traffic manager profile module in a global Azure resource group
* Implements Azure traffic manager endpoint and public ip module
* Implements two aks clusters in two different azure regions
* Supports aks cluster load balancer public ip configuration with Azure traffic manager end point.
* Adds role assignment with Contributor role for aks service principal so it's loadbalancer joins vnet/subnet which are in non aks node resource group.
* Adding location-clustername prefix to the kube config file name to avoid the overwrite.
* Cloning and installing Flux from unique directory for each cluster and location.
* Updated kube config copy instructions in readme to include <location-cluster> prefix in the file name.
* Removed bedrock implementation of Azure DevOps git repo implementation since flux supports by default.

Closes #42 
