### PR TITLE
Updated helm_init function of build.sh

### DIFF
--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -25,15 +25,6 @@ function init() {
 function helm_init() {
     echo "RUN HELM INIT"
     helm init
-    echo "HELM ADD INCUBATOR"
-    if [ -z "$HELM_CHART_REPO" ] || [ -z "$HELM_CHART_REPO_URL" ];
-    then
-        echo "Using DEFAULT helm repo..."
-        helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
-    else
-        echo "Using DEFINED helm repo..."
-        helm repo add $HELM_CHART_REPO $HELM_CHART_REPO_URL
-    fi
 }
 
 # Obtain version for Fabrikate


### PR DESCRIPTION
The helm_init function will no longer require the need to add helm repos for custom chart repos. This is resolved in Fabrikate (v.0.2.3+).