### PR TITLE
Bump k8s default version 

### DIFF
--- a/cluster/azure/aks/variables.tf
+++ b/cluster/azure/aks/variables.tf
@@ -34,7 +34,7 @@ variable "agent_vm_size" {
 
 variable "kubernetes_version" {
     type = "string"
-    default = "1.12.5"
+    default = "1.12.6"
 }
 
 variable "admin_user" {


### PR DESCRIPTION
1.12.5 --> 1.12.6 is now the latest version supported on AKS.