### PR TITLE
Adding link to Azure-Simple

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Bedrock also provides automation for deploying Kubernetes clusters with Terrafor
 
 ## Getting Started
 
+The easiest way to test Bedrock is to start with simple deployment to [Azure](https://github.com/Microsoft/bedrock/tree/master/cluster/environments/azure-simple) or to [minikube](https://github.com/Microsoft/bedrock/tree/master/cluster/environments/minikube) if you prefer to work locally.   
+
 A Bedrock deployment follows three general steps at a high level:
 
 1. Define a [Fabrikate](https://github.com/Microsoft/fabrikate) definition for your deployment.


### PR DESCRIPTION
Hello @dtzar  and @jmspring,

Thank you for giving me initial instructions how to start with Bedrock.

I think it will be useful to add a link to [azure-simple](https://github.com/Microsoft/bedrock/tree/master/cluster/environments/azure-simple) and [minikube](https://github.com/Microsoft/bedrock/tree/master/cluster/environments/minikube) as the easiest steps for exploring Bedrock without the need to setup too much infrastructure as I described in  https://github.com/Microsoft/bedrock/issues/257.

Please let me know if this is a good suggestion or how the introduction of [azure-simple](https://github.com/Microsoft/bedrock/tree/master/cluster/environments/azure-simple) should be presented.

Thank you!