### PR TITLE
Allow creation of branch in manifest repo

### DIFF
--- a/gitops/azure-devops/README.md
+++ b/gitops/azure-devops/README.md
@@ -44,6 +44,7 @@ steps:
   condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1
+    BRANCH_NAME: $(Build.SourceBranchName)
 
 - task: ShellScript@2
   displayName: Transform fabrikate definitions and publish to YAML manifests to repo
@@ -54,6 +55,7 @@ steps:
     ACCESS_TOKEN_SECRET: $(ACCESS_TOKEN)
     COMMIT_MESSAGE: $(Build.SourceVersionMessage)
     MANIFEST_REPO: $(MANIFEST_REPO)
+    BRANCH_NAME: $(Build.SourceBranchName)
 ```
 
 ### 2. Create Pipeline

--- a/gitops/azure-devops/README.md
+++ b/gitops/azure-devops/README.md
@@ -44,7 +44,6 @@ steps:
   condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1
-    BRANCH_NAME: $(Build.SourceBranchName)
 
 - task: ShellScript@2
   displayName: Transform fabrikate definitions and publish to YAML manifests to repo

--- a/gitops/azure-devops/README.md
+++ b/gitops/azure-devops/README.md
@@ -57,6 +57,8 @@ steps:
     BRANCH_NAME: $(Build.SourceBranchName)
 ```
 
+__Note__: If you would like to trigger the build on a branch other than master, add it to the above file under `trigger`
+
 ### 2. Create Pipeline
 
 We use an [Azure Pipelines Build](https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?toc=/azure/devops/pipelines/toc.json&bc=/azure/devops/boards/pipelines/breadcrumb/toc.json&view=azure-devops) to build your high level description into resource manifests:

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -131,8 +131,11 @@ function git_connect() {
 
 # Git commit
 function git_commit() {
-    echo "GIT CHECKOUT"
-    git checkout master
+    echo "GIT CHECKOUT $BRANCH_NAME"
+    if ! git checkout $BRANCH_NAME ; then
+        git checkout -b $BRANCH_NAME
+    fi
+    
     echo "GIT STATUS"
     git status
     echo "GIT REMOVE"
@@ -155,8 +158,8 @@ function git_commit() {
         echo "NOTHING TO COMMIT"
     fi
 
-    echo "GIT PULL" 
-    git pull
+    echo "GIT PULL origin $BRANCH_NAME" 
+    git pull origin $BRANCH_NAME
 }
 
 # Perform a Git push


### PR DESCRIPTION
This change should not break existing pipelines where `BRANCH_NAME` is not set in `azure-pipelines.yml`

Fixes #251 

