### PR TITLE
Resolve bug for passing empty strings for Flux variables (e.g. `gitops_path`)

### DIFF
--- a/cluster/common/flux/main.tf
+++ b/cluster/common/flux/main.tf
@@ -6,7 +6,7 @@ provider "null" {
 resource "null_resource" "deploy_flux" {
   count  = "${var.enable_flux ? 1 : 0}"
   provisioner "local-exec" {
-    command = "echo 'Need to use this var so terraform waits for kubeconfig ' ${var.kubeconfig_complete};KUBECONFIG=${var.output_directory}/${var.kubeconfig_filename} ${path.module}/deploy_flux.sh -b ${var.gitops_url_branch} -f ${var.flux_repo_url} -g ${var.gitops_ssh_url} -k ${var.gitops_ssh_key} -d ${var.flux_clone_dir} -c ${var.gitops_poll_interval} -e ${var.gitops_path} -s ${var.acr_enabled}"
+    command = "echo 'Need to use this var so terraform waits for kubeconfig ' ${var.kubeconfig_complete};KUBECONFIG=${var.output_directory}/${var.kubeconfig_filename} ${path.module}/deploy_flux.sh -b '${var.gitops_url_branch}' -f '${var.flux_repo_url}' -g '${var.gitops_ssh_url}' -k '${var.gitops_ssh_key}' -d '${var.flux_clone_dir}' -c '${var.gitops_poll_interval}' -e '${var.gitops_path}' -s '${var.acr_enabled}'"
   }
 
   triggers {

--- a/cluster/environments/azure-advanced/variables.tf
+++ b/cluster/environments/azure-advanced/variables.tf
@@ -41,7 +41,6 @@ variable "gitops_ssh_key" {
 
 variable "gitops_path" {
     type = "string"
-    default = "/"
 }
 
 variable "gitops_poll_interval" {


### PR DESCRIPTION
Added single quotes in `main.tf` to resolve issue with having empty strings being passed in for variable(s) like `gitops_path`.

https://github.com/Microsoft/bedrock/issues/260