### PR TITLE
Updating links in GitOps documentation

### DIFF
--- a/gitops/azure-devops/ADORepos.md
+++ b/gitops/azure-devops/ADORepos.md
@@ -29,7 +29,7 @@ $ az repos create --name $HLD_REPO_NAME
 $ az repos create --name $MANIFEST_REPO_NAME
 ```
 
-2. (optionally) If you are using our [sample HLD repo](https://github.com/samiyaakhtar/aks-deploy-source), import it with the following command:
+2. (optionally) If you are using our [sample HLD repo](https://github.com/andrebriggs/fabrikate-sample-app), import it with the following command:
 ```
 $ az repos import create --git-source-url $SAMPLE_HLD_REPO_PATH --repository HLD_REPO_NAME
 ```

--- a/gitops/azure-devops/GitHubRepos.md
+++ b/gitops/azure-devops/GitHubRepos.md
@@ -4,7 +4,7 @@
 
 ## 1. Create HLD Repository
 
-If you have not already, create your own high level definition repository.  (We provide a [sample GitHub repo](https://github.com/samiyaakhtar/aks-deploy-source) that you can fork and modify for your own application.)
+If you have not already, create your own high level definition repository.  (We provide a [sample GitHub repo](https://github.com/andrebriggs/fabrikate-sample-app) that you can fork and modify for your own application.)
 
 Also, make sure you have an [azure-pipelines.yml](README.md#azure-pipelines-build-yaml) file at the root of your repository, as we will use this later to setup the build rules in Azure Devops.
 

--- a/gitops/azure-devops/README.md
+++ b/gitops/azure-devops/README.md
@@ -5,7 +5,7 @@ This section describes how to configure Azure Devops as the CI/CD system for you
 ## Prerequisites
 
 1. _Permissions_: The ability to create Projects in your Azure DevOps Organization.
-2. _High Level Deployment Description_: Either your own [Fabrikate](https://github.com/Microsoft/fabrikate) high level definition for your deployment or a sample one of ours.  We provide a [sample HLD repo](https://github.com/samiyaakhtar/aks-deploy-source) that builds upon the [cloud-native](https://github.com/timfpark/fabrikate-cloud-native) Fabrikate definition.
+2. _High Level Deployment Description_: Either your own [Fabrikate](https://github.com/Microsoft/fabrikate) high level definition for your deployment or a sample one of ours.  We provide a [sample HLD repo](https://github.com/andrebriggs/fabrikate-sample-app) that builds upon the [cloud-native](https://github.com/timfpark/fabrikate-cloud-native) Fabrikate definition.
 
 ## Setup
 


### PR DESCRIPTION
Updated the sample app links for GitOps documentation to use https://github.com/andrebriggs/fabrikate-sample-app

Closes #301 