### PR TITLE
Adding environment variable.

### DIFF
--- a/gitops/azure-devops/BuildAppImage_ADOReleases.md
+++ b/gitops/azure-devops/BuildAppImage_ADOReleases.md
@@ -94,7 +94,7 @@ The `ACCESS_TOKEN` and `REPO` variables are specifically used in the `build.sh`,
 
 ![Release Pipeline Variable](images/releases-pipeline-var.png)
 
-The stages each involve two tasks: `Download scripts`, and `release.sh`. The `Download scripts` task downloads the `build.sh` and `release.sh` from the Microsoft/Bedrock repo.
+Each stage targets specific environment defined via the `ENVIRONMENT` variable. Each stage contains two tasks: `Download scripts`, and `release.sh`. The `Download scripts` task downloads the `build.sh` and `release.sh` from the Microsoft/Bedrock repo.
 
 ![Release Task 1](images/release-task1.png)
 
@@ -106,6 +106,8 @@ COMMIT_MESSAGE: custom message used when committing and pushing to git
 SUBCOMPONENT: the subcomponent within your Fabrikate HLD that should be manipulated
 YAML_PATH: the yaml path to the subkey to set (e.g. data.replicas)
 YAML_PATH_VALUE: the value to the subkey
+ENVIRONMENT: the targeted environment
+
 ```
 
 ![Release Task 2](images/release-task2.png)

--- a/gitops/azure-devops/release.sh
+++ b/gitops/azure-devops/release.sh
@@ -18,7 +18,7 @@ git_connect
 install_fab
 
 echo "FAB SET"
-fab set --subcomponent $SUBCOMPONENT $YAML_PATH=$YAML_PATH_VALUE
+fab set --environment $ENVIRONMENT --subcomponent $SUBCOMPONENT $YAML_PATH=$YAML_PATH_VALUE
 
 echo "GIT STATUS"
 git status


### PR DESCRIPTION
Hello @timfpark and @andrebriggs,

I am trying to figure out how to set environment when I am modifying the Fabrikate files.

In the same time I see that in the [release.sh](https://github.com/Microsoft/bedrock/blob/master/gitops/azure-devops/release.sh) we are setting only subcomponent.

How do we specify the enviorment we are targeting if we are not setting it explicitly in the  [release.sh](https://github.com/Microsoft/bedrock/blob/master/gitops/azure-devops/release.sh)?

```bash
echo "FAB SET"
fab set --subcomponent $SUBCOMPONENT $YAML_PATH=$YAML_PATH_VALUE
```

Thank you!

