### PR TITLE
Test GitOps pipeline as part of CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,3 +73,17 @@ steps:
     ARM_TENANT_ID: $(ARM_TENANT_ID)
   workingDirectory: '$(modulePath)/test'
   displayName: 'Create ssh keys, get deps, then test'
+
+- checkout: self
+  persistCredentials: true
+  clean: true
+  displayName: 'Checkout PR branch'
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+
+- task: ShellScript@2
+displayName: Validate fabrikate definitions
+inputs:
+  scriptPath: gitops/azure-devops/build.sh
+condition: eq(variables['Build.Reason'], 'PullRequest')
+env:
+  VERIFY_ONLY: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,6 @@ trigger:
   branches:
     include:
     - master
-    - 340
   paths:
     include:
     - /cluster/azure/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,16 +40,14 @@ steps:
 - checkout: self
   persistCredentials: true
   clean: true
-  # condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - task: ShellScript@2
-  displayName: Validate fabrikate definitions
+  displayName: Validate GitOps pipeline
   inputs:
     scriptPath: gitops/azure-devops/build.sh
-  # condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1
-    HLD_PATH: git://github.com/Microsoft/jackson-source.git
+    HLD_PATH: git://github.com/Microsoft/fabrikate-production-cluster-demo.git
     
 - script: |
     mkdir -p '$(GOBIN)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,6 @@ trigger:
     - /cluster/common/*
     - /cluster/environments/azure-simple/*
     exclude:
-    - gitops/*
     - README.md
 pr:
   autoCancel: false
@@ -23,7 +22,6 @@ pr:
     - /cluster/environments/azure-simple/*
     - /test/*
     exclude:
-    - gitops/*
     - README.md
 
 pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,12 +77,12 @@ steps:
 - checkout: self
   persistCredentials: true
   clean: true
-  condition: eq(variables['Build.Reason'], 'PullRequest')
+  # condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - task: ShellScript@2
   displayName: Validate fabrikate definitions
   inputs:
     scriptPath: gitops/azure-devops/build.sh
-  condition: eq(variables['Build.Reason'], 'PullRequest')
+  # condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1

--- a/gitops/azure-devops/README.md
+++ b/gitops/azure-devops/README.md
@@ -66,6 +66,8 @@ We use an [Azure Pipelines Build](https://docs.microsoft.com/en-us/azure/devops/
 1. On a pull request (pre push to master) it executes a simple validation on proposed changes to infrastructure definition in the HLD repo.
 1. On a merge to master branch (post push to master) it executes a script to transform the high level definition to YAML using [Fabrikate](https://github.com/Microsoft/fabrikate) and pushes the generated results into the resource manifest repo.
 
+__Note__: If you would like to trigger a build from a pipeline not linked to the high level definition repo, you can define a variable `HLD_PATH` and pass it into the script with other variables as shown above in `azure-pipelines.yml`. You need to set this to a git URL, such as `git://github.com/Microsoft/fabrikate-production-cluster-demo.git`.
+
 #### Create Build for your Definition Repo
 
 In Azure DevOps:

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -71,35 +71,34 @@ function download_fab() {
 
 # Install the HLD repo if it's not running as part of the HLD build pipeline
 function install_hld() {
+    echo "DOWNLOADING HLD REPO"
     echo "git clone $HLD_PATH"
     git clone $HLD_PATH
     # Extract repo name from url
     repo=${HLD_PATH##*/}
     repo_name=${repo%%.*}
     echo "Setting HLD path to $repo_name"
-    ls
-    pwd
     cd $repo_name
-    echo "HLD INSTALLED SUCCESSFULLY"
+    echo "HLD DOWNLOADED SUCCESSFULLY"
 }
 
 # Install Fabrikate
 function install_fab() {
     # Run this command to make script exit on any failure
-    echo "FAB INSTALL STARTING"
+    echo "FAB INSTALL"
     set -e
     export PATH=$PATH:$HOME/fab
 
     if [ -z "$HLD_PATH" ]; then 
-        echo "HLD path not specified, going to run fab install in current dir"
+        echo "HLD path not specified, running fab install in current dir"
     else
         echo "HLD repo specified: $HLD_PATH"
         install_hld
     fi
+
     fab install
     echo "FAB INSTALL COMPLETED"
 }
-
 
 # Run fab generate
 function fab_generate() {
@@ -119,10 +118,6 @@ function fab_generate() {
     fi
 
     echo "FAB GENERATE COMPLETED"
-    ls
-    pwd
-    echo "Checking if generated folder is available at $HOME"
-    ls $HOME
     set +e
 
     # If generated folder is empty, quit


### PR DESCRIPTION
Adding verifications to run as part of integration tests for the GitOps pipeline:
- checkout the current bedrock branch and run it against an HLD repo (currently, against [fabrikate-production-cluster-demo](https://github.com/Microsoft/fabrikate-production-cluster-demo)) to verify that manifests can be completed
- refactored some code in `build.sh` to support downloading an HLD if it's running from an independent build, such as this one

Fixes #340 