### PR TITLE
Test GitOps pipeline as part of CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,6 @@ trigger:
   branches:
     include:
     - master
-    - 340
   paths:
     include:
     - /cluster/azure/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,19 @@ variables:
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
 
 steps:
+- checkout: self
+  persistCredentials: true
+  clean: true
+  # condition: eq(variables['Build.Reason'], 'PullRequest')
+
+- task: ShellScript@2
+  displayName: Validate fabrikate definitions
+  inputs:
+    scriptPath: gitops/azure-devops/build.sh
+  # condition: eq(variables['Build.Reason'], 'PullRequest')
+  env:
+    VERIFY_ONLY: 1
+    
 - script: |
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
@@ -74,16 +87,3 @@ steps:
     ARM_TENANT_ID: $(ARM_TENANT_ID)
   workingDirectory: '$(modulePath)/test'
   displayName: 'Create ssh keys, get deps, then test'
-
-- checkout: self
-  persistCredentials: true
-  clean: true
-  # condition: eq(variables['Build.Reason'], 'PullRequest')
-
-- task: ShellScript@2
-  displayName: Validate fabrikate definitions
-  inputs:
-    scriptPath: gitops/azure-devops/build.sh
-  # condition: eq(variables['Build.Reason'], 'PullRequest')
-  env:
-    VERIFY_ONLY: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,10 @@ steps:
   clean: true
   # condition: eq(variables['Build.Reason'], 'PullRequest')
 
+- script: |
+    git clone https://github.com/Microsoft/fabrikate-production-cluster-demo.git
+  displayName: 'Clone HLD Repo'
+
 - task: ShellScript@2
   displayName: Validate fabrikate definitions
   inputs:
@@ -49,6 +53,7 @@ steps:
   # condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1
+    HLD_PATH: fabrikate-production-cluster-demo
     
 - script: |
     mkdir -p '$(GOBIN)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,3 +73,16 @@ steps:
     ARM_TENANT_ID: $(ARM_TENANT_ID)
   workingDirectory: '$(modulePath)/test'
   displayName: 'Create ssh keys, get deps, then test'
+
+- checkout: self
+  persistCredentials: true
+  clean: true
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+
+- task: ShellScript@2
+  displayName: Validate fabrikate definitions
+  inputs:
+    scriptPath: gitops/azure-devops/build.sh
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+  env:
+    VERIFY_ONLY: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,12 +78,12 @@ steps:
 - checkout: self
   persistCredentials: true
   clean: true
-  condition: eq(variables['Build.Reason'], 'PullRequest')
+  # condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - task: ShellScript@2
   displayName: Validate fabrikate definitions
   inputs:
     scriptPath: gitops/azure-devops/build.sh
-  condition: eq(variables['Build.Reason'], 'PullRequest')
+  # condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ trigger:
     - /cluster/azure/*
     - /cluster/common/*
     - /cluster/environments/azure-simple/*
+    - gitops/*
     exclude:
     - README.md
 pr:
@@ -21,6 +22,7 @@ pr:
     - /cluster/common/*
     - /cluster/environments/azure-simple/*
     - /test/*
+    - gitops/*
     exclude:
     - README.md
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ steps:
   # condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - script: |
-    git clone git://github.com/Microsoft/fabrikate-production-cluster-demo.git
+    git clone git://github.com/samiyaakhtar/jackson-source.git
   displayName: 'Clone HLD Repo'
 
 - task: ShellScript@2
@@ -53,7 +53,7 @@ steps:
   # condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1
-    HLD_PATH: fabrikate-production-cluster-demo
+    HLD_PATH: jackson-source
     
 - script: |
     mkdir -p '$(GOBIN)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ steps:
   # condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - script: |
-    git clone https://github.com/Microsoft/fabrikate-production-cluster-demo
+    git clone git://github.com/Microsoft/fabrikate-production-cluster-demo.git
   displayName: 'Clone HLD Repo'
 
 - task: ShellScript@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,12 +42,6 @@ steps:
   clean: true
   # condition: eq(variables['Build.Reason'], 'PullRequest')
 
-- script: |
-    git clone git://github.com/samiyaakhtar/jackson-source.git
-    ls
-    pwd
-  displayName: 'Clone HLD Repo'
-
 - task: ShellScript@2
   displayName: Validate fabrikate definitions
   inputs:
@@ -55,7 +49,7 @@ steps:
   # condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1
-    HLD_PATH: jackson-source
+    HLD_PATH: git://github.com/samiyaakhtar/jackson-source.git
     
 - script: |
     mkdir -p '$(GOBIN)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,6 @@ trigger:
     - /cluster/common/*
     - /cluster/environments/azure-simple/*
     exclude:
-    - gitops/*
     - README.md
 pr:
   autoCancel: false
@@ -24,7 +23,6 @@ pr:
     - /cluster/environments/azure-simple/*
     - /test/*
     exclude:
-    - gitops/*
     - README.md
 
 pool:
@@ -40,16 +38,14 @@ steps:
 - checkout: self
   persistCredentials: true
   clean: true
-  # condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - task: ShellScript@2
-  displayName: Validate fabrikate definitions
+  displayName: Validate GitOps pipeline
   inputs:
     scriptPath: gitops/azure-devops/build.sh
-  # condition: eq(variables['Build.Reason'], 'PullRequest')
   env:
     VERIFY_ONLY: 1
-    HLD_PATH: git://github.com/samiyaakhtar/jackson-source.git
+    HLD_PATH: git://github.com/Microsoft/fabrikate-production-cluster-demo.git
     
 - script: |
     mkdir -p '$(GOBIN)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,8 @@ steps:
 
 - script: |
     git clone git://github.com/samiyaakhtar/jackson-source.git
+    ls
+    pwd
   displayName: 'Clone HLD Repo'
 
 - task: ShellScript@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ steps:
   # condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - script: |
-    git clone https://github.com/Microsoft/fabrikate-production-cluster-demo.git
+    git clone https://github.com/Microsoft/fabrikate-production-cluster-demo
   displayName: 'Clone HLD Repo'
 
 - task: ShellScript@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - master
+    - 340
   paths:
     include:
     - /cluster/azure/*

--- a/gitops/azure-devops/README.md
+++ b/gitops/azure-devops/README.md
@@ -66,6 +66,8 @@ We use an [Azure Pipelines Build](https://docs.microsoft.com/en-us/azure/devops/
 1. On a pull request (pre push to master) it executes a simple validation on proposed changes to infrastructure definition in the HLD repo.
 1. On a merge to master branch (post push to master) it executes a script to transform the high level definition to YAML using [Fabrikate](https://github.com/Microsoft/fabrikate) and pushes the generated results into the resource manifest repo.
 
+__Note__: If you would like to trigger a build from a pipeline not linked to the high level definition repo, you can define a variable `HLD_PATH` and pass it into the script with other variables as shown above in `azure-pipelines.yml`. You need to set this to a git URL, such as `git://github.com/Microsoft/fabrikate-production-cluster-demo.git`.
+
 #### Create Build for your Definition Repo
 
 In Azure DevOps:

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -128,7 +128,7 @@ function fab_generate() {
     # If generated folder is empty, quit
     # In the case that all components are removed from the source hld,
     # generated folder should still not be empty
-    if find "$HOME/generated" -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
+    if find "generated" -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
         echo "Manifest files have been generated."
     else
         echo "Manifest files could not be generated, quitting..."

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -71,22 +71,21 @@ function download_fab() {
 
 # Install the HLD repo if it's not running as part of the HLD build pipeline
 function install_hld() {
+    echo "DOWNLOADING HLD REPO"
     echo "git clone $HLD_PATH"
     git clone $HLD_PATH
     # Extract repo name from url
     repo=${HLD_PATH##*/}
     repo_name=${repo%%.*}
     echo "Setting HLD path to $repo_name"
-    ls
-    pwd
     cd $repo_name
-    echo "HLD INSTALLED SUCCESSFULLY"
+    echo "HLD DOWNLOADED SUCCESSFULLY"
 }
 
 # Install Fabrikate
 function install_fab() {
     # Run this command to make script exit on any failure
-    echo "FAB INSTALL STARTING"
+    echo "FAB INSTALL"
     set -e
     export PATH=$PATH:$HOME/fab
 
@@ -119,10 +118,6 @@ function fab_generate() {
     fi
 
     echo "FAB GENERATE COMPLETED"
-    ls
-    pwd
-    echo "Checking if generated folder is available at $HOME"
-    ls $HOME
     set +e
 
     # If generated folder is empty, quit

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -76,11 +76,10 @@ function install_hld() {
     # Extract repo name from url
     repo=${HLD_PATH##*/}
     repo_name=${repo%%.*}
-    echo "Setting HLD path to $repo_name, repo = $repo"
+    echo "Setting HLD path to $repo_name"
     ls
     pwd
-    cd $HLD_PATH
-    
+    cd $repo_name
     echo "HLD INSTALLED SUCCESSFULLY"
 }
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -77,6 +77,8 @@ function install_fab() {
     export PATH=$PATH:$HOME/fab
 
     if [ -z "$HLD_PATH" ]; then 
+        echo "HLD path not specified, going to run fab install in current dir"
+    else
         echo "Setting HLD path to $HLD_PATH"
         cd $HLD_PATH
     fi

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -72,6 +72,7 @@ function download_fab() {
 # Install Fabrikate
 function install_fab() {
     # Run this command to make script exit on any failure
+    echo "FAB INSTALL STARTING"
     set -e
     export PATH=$PATH:$HOME/fab
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -74,11 +74,14 @@ function install_hld() {
     echo "git clone $HLD_PATH"
     git clone $HLD_PATH
     # Extract repo name from url
-    repo_name=${HLD_PATH%.*}
-    echo "Setting HLD path to $repo_name"
-    ls
-    pwd
-    cd $HLD_PATH
+    re="^(https|git)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$"
+    if [[ $HLD_PATH =~ $re ]]; then 
+        repo = ${BASH_REMATCH[5]}
+        echo "Setting HLD path to $repo"
+        ls
+        pwd
+        cd $HLD_PATH
+    fi
     echo "HLD INSTALLED SUCCESSFULLY"
 }
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -74,14 +74,13 @@ function install_hld() {
     echo "git clone $HLD_PATH"
     git clone $HLD_PATH
     # Extract repo name from url
-    re="^(https|git)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$"
-    if [[ $HLD_PATH =~ $re ]]; then 
-        repo = ${BASH_REMATCH[5]}
-        echo "Setting HLD path to $repo"
-        ls
-        pwd
-        cd $HLD_PATH
-    fi
+    repo=${HLD_PATH##*/}
+    repo_name=${repo%%.*}
+    echo "Setting HLD path to $repo_name, repo = $repo"
+    ls
+    pwd
+    cd $HLD_PATH
+    
     echo "HLD INSTALLED SUCCESSFULLY"
 }
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -18,7 +18,6 @@ function verify_repo() {
 function init() {
     cp -r * $HOME/
     cd $HOME
-    verify_repo
 }
 
 # Initialize Helm
@@ -75,6 +74,11 @@ function install_fab() {
     # Run this command to make script exit on any failure
     set -e
     export PATH=$PATH:$HOME/fab
+
+    if [ -z "$HLD_PATH" ]; then 
+        echo "Setting HLD path to $HLD_PATH"
+        cd $HLD_PATH
+    fi
     fab install
     echo "FAB INSTALL COMPLETED"
 }
@@ -192,6 +196,7 @@ function verify_pull_request() {
 
 # Run functions
 function verify_pull_request_and_merge() {
+    verify_repo
     verify_access_token
     verify_pull_request
     echo "Verification complete, push to yaml repo"

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -119,7 +119,10 @@ function fab_generate() {
     fi
 
     echo "FAB GENERATE COMPLETED"
-
+    ls
+    pwd
+    echo "Checking if generated folder is available at $HOME"
+    ls $HOME
     set +e
 
     # If generated folder is empty, quit

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -80,6 +80,7 @@ function install_fab() {
         echo "HLD path not specified, going to run fab install in current dir"
     else
         echo "Setting HLD path to $HLD_PATH"
+        ls
         cd $HLD_PATH
     fi
     fab install

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -81,6 +81,7 @@ function install_fab() {
     else
         echo "Setting HLD path to $HLD_PATH"
         ls
+        pwd
         cd $HLD_PATH
     fi
     fab install

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -69,6 +69,19 @@ function download_fab() {
     unzip fab-v$VERSION_TO_DOWNLOAD-$os-amd64.zip -d fab
 }
 
+# Install the HLD repo if it's not running as part of the HLD build pipeline
+function install_hld() {
+    echo "git clone $HLD_PATH"
+    git clone $HLD_PATH
+    # Extract repo name from url
+    repo_name=${HLD_PATH%.*}
+    echo "Setting HLD path to $repo_name"
+    ls
+    pwd
+    cd $HLD_PATH
+    echo "HLD INSTALLED SUCCESSFULLY"
+}
+
 # Install Fabrikate
 function install_fab() {
     # Run this command to make script exit on any failure
@@ -79,14 +92,13 @@ function install_fab() {
     if [ -z "$HLD_PATH" ]; then 
         echo "HLD path not specified, going to run fab install in current dir"
     else
-        echo "Setting HLD path to $HLD_PATH"
-        ls
-        pwd
-        cd $HLD_PATH
+        echo "HLD repo specified: $HLD_PATH"
+        install_hld
     fi
     fab install
     echo "FAB INSTALL COMPLETED"
 }
+
 
 # Run fab generate
 function fab_generate() {


### PR DESCRIPTION
Adding verifications to run as part of integration tests for the GitOps pipeline:
- checkout the current bedrock branch and run it against an HLD repo (currently, against [fabrikate-production-cluster-demo](https://github.com/Microsoft/fabrikate-production-cluster-demo)) to verify that manifests can be completed
- refactored some code in `build.sh` to support downloading an HLD if it's running from an independent build, such as this one

Fixes #340 