### PR TITLE
Plumb through enable_flux to aks-gitops interface

### DIFF
--- a/cluster/azure/aks-gitops/main.tf
+++ b/cluster/azure/aks-gitops/main.tf
@@ -24,6 +24,7 @@ module "flux" {
   gitops_ssh_key       = "${var.gitops_ssh_key}"
   gitops_path          = "${var.gitops_path}"
   gitops_poll_interval = "${var.gitops_poll_interval}"
+  enable_flux          = "${var.enable_flux}"
   flux_recreate        = "${var.flux_recreate}"
   kubeconfig_complete  = "${module.aks.kubeconfig_done}"
   flux_clone_dir       = "${var.cluster_name}-flux"

--- a/cluster/azure/aks-gitops/variables.tf
+++ b/cluster/azure/aks-gitops/variables.tf
@@ -19,6 +19,11 @@ variable "dns_prefix" {
   type = "string"
 }
 
+variable "enable_flux" {
+  type = "string"
+  default = "true"
+}
+
 variable "flux_recreate" {
   type = "string"
 }


### PR DESCRIPTION
Work towards enabling #366 (backup and restore of cluster)

Plumbing through enable_flux would enable us to operationalize a restore:
- Operator would deploy a new cluster without flux (`enable_flux = false`).
- Operator would trigger a restore of the previous backup from the failed cluster onto the new cluster (because Flux has not created PVs for all of the disks already it will use the snapshotted ones).
- Operator would adjust `enable_flux = true` and then `terraform apply` again to deploy flux and resume normal operations.