### PR TITLE
Fix sh issues in deploy_flux.sh

### DIFF
--- a/cluster/common/flux/deploy_flux.sh
+++ b/cluster/common/flux/deploy_flux.sh
@@ -12,6 +12,8 @@ do
  s) ACR_ENABLED=${OPTARG};;
  r) FLUX_IMAGE_REPOSITORY=${OPTARG};;
  t) FLUX_IMAGE_TAG=${OPTARG};;
+ *) echo "Please refer to usage guide on GitHub" >&2
+    exit 1 ;;
  esac
 done
 

--- a/cluster/common/flux/deploy_flux.sh
+++ b/cluster/common/flux/deploy_flux.sh
@@ -25,27 +25,27 @@ FLUX_MANIFESTS="manifests"
 
 echo "flux repo root directory: $REPO_ROOT_DIR"
 
-rm -rf $REPO_ROOT_DIR
+rm -rf "$REPO_ROOT_DIR"
 
 echo "creating $REPO_ROOT_DIR directory"
-if ! mkdir $REPO_ROOT_DIR; then
+if ! mkdir "$REPO_ROOT_DIR"; then
     echo "ERROR: failed to create directory $REPO_ROOT_DIR"
     exit 1
 fi
 
-cd $REPO_ROOT_DIR
+cd "$REPO_ROOT_DIR"
 
 echo "cloning $FLUX_REPO_URL"
 
-if ! git clone -b $FLUX_IMAGE_TAG $FLUX_REPO_URL; then
+if ! git clone -b "$FLUX_IMAGE_TAG" "$FLUX_REPO_URL"; then
     echo "ERROR: failed to clone $FLUX_REPO_URL"
     exit 1
 fi
 
-cd $CLONE_DIR/$FLUX_CHART_DIR
+cd "$CLONE_DIR/$FLUX_CHART_DIR"
 
 echo "creating $FLUX_MANIFESTS directory"
-if ! mkdir $FLUX_MANIFESTS; then
+if ! mkdir "$FLUX_MANIFESTS"; then
     echo "ERROR: failed to create directory $FLUX_MANIFESTS"
     exit 1
 fi
@@ -55,12 +55,12 @@ fi
 #   git url: where flux monitors for manifests
 #   git ssh secret: kubernetes secret object for flux to read/write access to manifests repo
 echo "generating flux manifests with helm template"
-if ! helm template . --name $RELEASE_NAME --namespace $KUBE_NAMESPACE --values values.yaml --set image.repository=$FLUX_IMAGE_REPOSITORY --set image.tag=$FLUX_IMAGE_TAG --output-dir ./$FLUX_MANIFESTS --set git.url=$GITOPS_SSH_URL --set git.branch=$GITOPS_URL_BRANCH --set git.secretName=$KUBE_SECRET_NAME --set git.path=$GITOPS_PATH --set git.pollInterval=$GITOPS_POLL_INTERVAL --set registry.acr.enabled=$ACR_ENABLED; then
+if ! helm template . --name "$RELEASE_NAME" --namespace "$KUBE_NAMESPACE" --values values.yaml --set image.repository="$FLUX_IMAGE_REPOSITORY" --set image.tag="$FLUX_IMAGE_TAG" --output-dir "./$FLUX_MANIFESTS" --set git.url="$GITOPS_SSH_URL" --set git.branch="$GITOPS_URL_BRANCH" --set git.secretName="$KUBE_SECRET_NAME" --set git.path="$GITOPS_PATH" --set git.pollInterval="$GITOPS_POLL_INTERVAL" --set registry.acr.enabled="$ACR_ENABLED"; then
     echo "ERROR: failed to helm template"
     exit 1
 fi
 
-# back to the roor dir
+# back to the root dir
 cd ../../../../
 
 
@@ -78,25 +78,25 @@ if kubectl get secret $KUBE_SECRET_NAME -n $KUBE_NAMESPACE > /dev/null 2>&1; the
     # kubectl doesn't provide a native way to patch a secret using --from-file.
     # The update path requires loading the secret, base64 encoding it, and then
     # making a call to the 'kubectl patch secret' command.
-    if [ ! -f $GITOPS_SSH_KEY ]; then
+    if [ ! -f "$GITOPS_SSH_KEY" ]; then
         echo "ERROR: unable to load GITOPS_SSH_KEY: $GITOPS_SSH_KEY"
         exit 1
     fi
 
-    secret=$(cat $GITOPS_SSH_KEY | base64)
+    secret=$(cat "$GITOPS_SSH_KEY" | base64)
     if ! kubectl patch secret $KUBE_SECRET_NAME -n $KUBE_NAMESPACE -p="{\"data\":{\"identity\": \"$secret\"}}"; then
         echo "ERROR: failed to patch existing flux secret: $KUBE_SECRET_NAME "
         exit 1
     fi
 else
-    if ! kubectl create secret generic $KUBE_SECRET_NAME --from-file=identity=$GITOPS_SSH_KEY -n $KUBE_NAMESPACE; then
+    if ! kubectl create secret generic $KUBE_SECRET_NAME --from-file=identity="$GITOPS_SSH_KEY" -n $KUBE_NAMESPACE; then
         echo "ERROR: failed to create secret: $KUBE_SECRET_NAME"
         exit 1
     fi
 fi
 
 echo "Applying flux deployment"
-if ! kubectl apply -f  $REPO_DIR/$FLUX_CHART_DIR/$FLUX_MANIFESTS/flux/templates -n $KUBE_NAMESPACE; then
+if ! kubectl apply -f  "$REPO_DIR/$FLUX_CHART_DIR/$FLUX_MANIFESTS/flux/templates" -n $KUBE_NAMESPACE; then
     echo "ERROR: failed to apply flux deployment"
     exit 1
 fi


### PR DESCRIPTION
- Added missing double quotes to prevent globbing and word splitting.
- Handle invalid flags in getops.

Haven't looked at other sh scripts, just happened to be working on this one. 

Refer to https://github.com/koalaman/shellcheck/wiki/SC2086