### PR TITLE
Fixed markdown exclude from build pipeline.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,7 @@ trigger:
     - azure-pipelines.yml
     exclude:
     - gitops/*
-    - README.md
-    - /*.md
+    - '**/*.md'
 pr:
   autoCancel: false
   branches:
@@ -34,8 +33,7 @@ pr:
     - gitops/*
     - azure-pipelines.yml
     exclude:
-    - README.md
-    - /*.md
+    - '**/*.md'
 
 
 jobs:


### PR DESCRIPTION
Fixed build pipeline to stop triggering builds for changes to markdown files everywhere instead of just the root directory.