### PR TITLE
[Low Priority] Add Linting for Shell Scripts to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
 
   - bash: |
       # Fail if any of these files have warnings
-      find . -type f \( -name "*.sh" -o -name "*.bash" -o -name "*.ksh" \) -print |
+      find . -path ./gopath -prune -o -path ./get_helm.sh -prune -o -type f \( -name "*.sh" -o -name "*.bash" -o -name "*.ksh" \) -print |
         while IFS="" read -r file
         do
           shellcheck "$file"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,6 +89,11 @@ jobs:
     displayName: 'Install terraform, kubectl, helm'
 
   - script: |
+      # Fail if any of these files have warnings
+      shellcheck **/*.sh
+    displayName: 'Run Shell Linting (ShellCheck)'
+
+  - script: |
       terraform fmt -check=true -write=false -list=true > /dev/null
       if [ $? -eq 0 ]
       then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,9 +88,13 @@ jobs:
       ./get_helm.sh
     displayName: 'Install terraform, kubectl, helm'
 
-  - script: |
+  - bash: |
       # Fail if any of these files have warnings
-      shellcheck **/*.sh
+      find . -type f \( -name "*.sh" -o -name "*.bash" -o -name "*.ksh" \) -print |
+        while IFS="" read -r file
+        do
+          shellcheck "$file"
+        done
     displayName: 'Run Shell Linting (ShellCheck)'
 
   - script: |

--- a/cluster/azure/keyvault_flexvol/deploy_flexvol.sh
+++ b/cluster/azure/keyvault_flexvol/deploy_flexvol.sh
@@ -6,20 +6,23 @@ do
  case "${option}" in 
  i) SERVICE_PRINCIPAL_ID=${OPTARG};;
  p) SERVICE_PRINCIPAL_SECRET=${OPTARG};;
- u) FLEXVOL_DEPLOYMENT_URL=${OPTARG};; 
+ u) FLEXVOL_DEPLOYMENT_URL=${OPTARG};;
+ *) echo "ERROR: Please refer to usage guide on GitHub" >&2
+    exit 1 ;;
  esac
 done 
 
 # Deploy the flex volume support into the cluster
-kubectl create -f $FLEXVOL_DEPLOYMENT_URL
-if [ $? != 0 ]; then
+if ! kubectl create -f "$FLEXVOL_DEPLOYMENT_URL"
+then
     echo "Unable to deploy flex volume support to cluster."
     exit 1
 fi
 
 echo "Adding service principal into KeyVault as a secret"
-kubectl create secret generic kvcreds --from-literal clientid=$SERVICE_PRINCIPAL_ID --from-literal clientsecret=$SERVICE_PRINCIPAL_SECRET --type=azure/kv
-if [ $? != 0 ]; then
+
+if ! kubectl create secret generic kvcreds --from-literal clientid="$SERVICE_PRINCIPAL_ID" --from-literal clientsecret="$SERVICE_PRINCIPAL_SECRET" --type=azure/kv
+then
     echo "Unable to add service principal secrets to kubectl secret"
     exit 1
 fi

--- a/cluster/azure/service-principal/scripts/allocate_resource_group_contributor.sh
+++ b/cluster/azure/service-principal/scripts/allocate_resource_group_contributor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -x
 
-if ! jq -v > /dev/null
+if ! jq --version > /dev/null
 then
     echo "This script requires 'jq', please install it."
     exit 1

--- a/cluster/azure/service-principal/scripts/allocate_resource_group_contributor.sh
+++ b/cluster/azure/service-principal/scripts/allocate_resource_group_contributor.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
-which jq > /dev/null
-if [ "$?" -ne "0" ]; then
+if ! jq -v > /dev/null
+then
     echo "This script requires 'jq', please install it."
     exit 1
 fi
@@ -12,6 +12,8 @@ do
     case "${option}" in
     r) RESOURCE_GROUP=${OPTARG};;
     l) RESOURCE_GROUP_LOCATION=${OPTARG};;
+    *) echo "ERROR: Please refer to usage guide on GitHub" >&2
+        exit 1 ;;
     esac
 done
 
@@ -21,10 +23,10 @@ if [ -z "$RESOURCE_GROUP" ] || [ -z "$RESOURCE_GROUP_LOCATION" ]; then
 fi
 
 # create resource group and retrieve id
-RESOURCE_GROUP_INFO=`az group create -n $RESOURCE_GROUP -l $RESOURCE_GROUP_LOCATION`
-RESOURCE_GROUP_ID=`echo $RESOURCE_GROUP_INFO | jq -r '.id'`
+RESOURCE_GROUP_INFO=$(az group create -n "$RESOURCE_GROUP" -l "$RESOURCE_GROUP_LOCATION")
+RESOURCE_GROUP_ID=$(echo "$RESOURCE_GROUP_INFO" | jq -r '.id')
 
 # create service principal with contributor role on resource group
-SERVICE_PRINCIPAL=`az ad sp create-for-rbac --role contributor --scopes $RESOURCE_GROUP_ID`
+SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --role contributor --scopes "$RESOURCE_GROUP_ID")
 echo "Service principal:"
-echo $SERVICE_PRINCIPAL
+echo "$SERVICE_PRINCIPAL"

--- a/cluster/azure/service-principal/scripts/create_service_principal_with_subscription_role.sh
+++ b/cluster/azure/service-principal/scripts/create_service_principal_with_subscription_role.sh
@@ -1,8 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 while getopts :r:s: option
 do
     case "${option}" in
     r) ROLE=${OPTARG};;
+    *) echo "ERROR: Please refer to usage guide on GitHub" >&2
+        exit 1 ;;
     esac
 done
 
@@ -11,9 +14,9 @@ if [ -z "$ROLE" ]; then
     exit 1
 fi
 
-AZ_ACCOUNT_INFO=`az account show`
-AZ_CLI_SUBSCRIPTION=`echo $AZ_ACCOUNT_INFO | jq -r '.id'`
+AZ_ACCOUNT_INFO=$(az account show)
+AZ_CLI_SUBSCRIPTION=$(echo "$AZ_ACCOUNT_INFO" | jq -r '.id')
 
-SERVICE_PRINCIPAL=`az ad sp create-for-rbac --role $ROLE --scopes /subscriptions/$AZ_CLI_SUBSCRIPTION`
+SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --role "$ROLE" --scopes /subscriptions/"$AZ_CLI_SUBSCRIPTION")
 echo "Service principal:"
-echo $SERVICE_PRINCIPAL
+echo "$SERVICE_PRINCIPAL"

--- a/cluster/azure/service-principal/scripts/determine_user_subscription_roles.sh
+++ b/cluster/azure/service-principal/scripts/determine_user_subscription_roles.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Check for dependencies
-if ! jq -v > /dev/null
+if ! jq --version > /dev/null
 then
     echo "This script requires 'jq', please install it."
     exit 1

--- a/cluster/azure/service-principal/scripts/determine_user_subscription_roles.sh
+++ b/cluster/azure/service-principal/scripts/determine_user_subscription_roles.sh
@@ -1,19 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check for dependencies
-which jq > /dev/null
-if [ "$?" -ne "0" ]; then
+if ! jq -v > /dev/null
+then
     echo "This script requires 'jq', please install it."
     exit 1
 fi
 
 # Retrieve account information
-AZ_ACCOUNT_INFO=`az account show`
-AZ_CLI_USER=`echo $AZ_ACCOUNT_INFO | jq -r '.user.name'`
-AZ_CLI_SUBSCRIPTION=`echo $AZ_ACCOUNT_INFO | jq -r '.id'`
+AZ_ACCOUNT_INFO=$(az account show)
+AZ_CLI_USER=$(echo "$AZ_ACCOUNT_INFO" | jq -r '.user.name')
+AZ_CLI_SUBSCRIPTION=$(echo "$AZ_ACCOUNT_INFO" | jq -r '.id')
 
 # Retrieve role information for user on the subscription
-ACCOUNT_SUBSCRIPTION_ROLES=`az role assignment list --assignee $AZ_CLI_USER | jq -c ".[] | select( .scope == \"/subscriptions/$AZ_CLI_SUBSCRIPTION\" )" | jq -r '.roleDefinitionName'`
+ACCOUNT_SUBSCRIPTION_ROLES=$(az role assignment list --assignee "$AZ_CLI_USER" | jq -c ".[] | select( .scope == \"/subscriptions/$AZ_CLI_SUBSCRIPTION\" )" | jq -r '.roleDefinitionName')
 
 echo "User roles for $AZ_CLI_USER on subscription $AZ_CLI_SUBSCRIPTION: "
 for role in $ACCOUNT_SUBSCRIPTION_ROLES; do

--- a/cluster/common/flux/deploy_flux.sh
+++ b/cluster/common/flux/deploy_flux.sh
@@ -35,7 +35,7 @@ if ! mkdir "$REPO_ROOT_DIR"; then
     exit 1
 fi
 
-cd "$REPO_ROOT_DIR"
+cd "$REPO_ROOT_DIR" || exit 1
 
 echo "cloning $FLUX_REPO_URL"
 
@@ -44,7 +44,7 @@ if ! git clone -b "$FLUX_IMAGE_TAG" "$FLUX_REPO_URL"; then
     exit 1
 fi
 
-cd "$CLONE_DIR/$FLUX_CHART_DIR"
+cd "$CLONE_DIR/$FLUX_CHART_DIR" || exit 1
 
 echo "creating $FLUX_MANIFESTS directory"
 if ! mkdir "$FLUX_MANIFESTS"; then
@@ -63,7 +63,7 @@ if ! helm template . --name "$RELEASE_NAME" --namespace "$KUBE_NAMESPACE" --valu
 fi
 
 # back to the root dir
-cd ../../../../
+cd ../../../../ || exit 1
 
 
 echo "creating kubernetes namespace $KUBE_NAMESPACE if needed"
@@ -85,7 +85,7 @@ if kubectl get secret $KUBE_SECRET_NAME -n $KUBE_NAMESPACE > /dev/null 2>&1; the
         exit 1
     fi
 
-    secret=$(cat "$GITOPS_SSH_KEY" | base64)
+    secret=$(< "$GITOPS_SSH_KEY" base64)
     if ! kubectl patch secret $KUBE_SECRET_NAME -n $KUBE_NAMESPACE -p="{\"data\":{\"identity\": \"$secret\"}}"; then
         echo "ERROR: failed to patch existing flux secret: $KUBE_SECRET_NAME "
         exit 1

--- a/cluster/common/kubediff/deploy_kubediff.sh
+++ b/cluster/common/kubediff/deploy_kubediff.sh
@@ -1,9 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 while getopts :f:g: option
 do
  case "${option}" in
  f) KUBEDIFF_REPO_URL=${OPTARG};;
- g) GITOPS_SSH_URL=${OPTARG};; 
+ g) GITOPS_SSH_URL=${OPTARG};;
+  *) echo "Please refer to usage guide on GitHub" >&2
+    exit 1 ;;
  esac
 done
  
@@ -12,12 +15,12 @@ REPO_DIR="kubediff"
 
 rm -rf $REPO_DIR
 echo "Cloning Kubediff $KUBEDIFF_REPO_URL"
-if ! git clone $KUBEDIFF_REPO_URL $REPO_DIR; then
+if ! git clone "$KUBEDIFF_REPO_URL" $REPO_DIR; then
     echo "ERROR: failed to clone $KUBEDIFF_REPO_URL"
     exit 1
 fi
 
-cd $REPO_DIR/k8s
+cd "$REPO_DIR/k8s" || exit 1
 
 re="^(https|git)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$"
 if [[ $GITOPS_SSH_URL =~ $re ]]; then
@@ -45,7 +48,7 @@ fi
 echo "Updated with gitops url $GITOPS_SSH_URL"
 sed '23q;d' ./kubediff-rc.yaml
 
-cd ../../ 
+cd ../../ || exit 1
 
 echo "creating kubernetes namespace $KUBEDIFF_NAMESPACE if needed"
 if ! kubectl describe namespace $KUBEDIFF_NAMESPACE > /dev/null 2>&1; then  

--- a/cluster/environments/minikube/deploy_minikube.sh
+++ b/cluster/environments/minikube/deploy_minikube.sh
@@ -8,4 +8,4 @@ FLUX_REPO_URL="https://github.com/weaveworks/flux.git"
 REPO_ROOT_DIR="repo-root"
 
 # install flux into cluster
-./../../common/flux/deploy_flux.sh -g $GITOPS_SSH_URL -b $GITOPS_SSH_BRANCH -k $GITOPS_SSH_KEY -f $FLUX_REPO_URL -d $REPO_ROOT_DIR
+./../../common/flux/deploy_flux.sh -g "$GITOPS_SSH_URL" -b "$GITOPS_SSH_BRANCH" -k "$GITOPS_SSH_KEY" -f "$FLUX_REPO_URL" -d "$REPO_ROOT_DIR"

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -9,6 +9,7 @@ function verify_access_token() {
 }
 function verify_repo() {
     echo "CHECKING HLD/MANIFEST REPO URL"
+    # shellcheck disable=SC2153
     if [[ -z "$REPO" ]]; then
         echo "HLD/MANIFEST REPO URL not specified in variable $REPO"
         exit 1
@@ -29,6 +30,7 @@ function helm_init() {
 # Obtain version for Fabrikate
 # If the version number is not provided, then download the latest
 function get_fab_version() {
+    # shellcheck disable=SC2153
     if [ -z "$VERSION" ]
     then
         VERSIONS=$(curl -s https://api.github.com/repos/Microsoft/fabrikate/tags)

--- a/gitops/azure-devops/release.sh
+++ b/gitops/azure-devops/release.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091
 . build.sh --source-only
 
 # Initialization

--- a/gitops/azure-devops/release.sh
+++ b/gitops/azure-devops/release.sh
@@ -1,4 +1,5 @@
-# Source build.sh
+#!/usr/bin/env bash
+
 . build.sh --source-only
 
 # Initialization
@@ -15,11 +16,11 @@ download_fab
 git_connect
 
 echo "FAB SET"
-if [[ ! -z $FAB_ENV_NAME ]]
+if [[ -n $FAB_ENV_NAME ]]
 then
-    fab set --environment $FAB_ENV_NAME --subcomponent $SUBCOMPONENT $YAML_PATH=$YAML_PATH_VALUE
+    fab set --environment "$FAB_ENV_NAME" --subcomponent "$SUBCOMPONENT" "$YAML_PATH=$YAML_PATH_VALUE"
 else
-    fab set --subcomponent $SUBCOMPONENT $YAML_PATH=$YAML_PATH_VALUE
+    fab set --subcomponent "$SUBCOMPONENT" "$YAML_PATH=$YAML_PATH_VALUE"
 fi
 
 echo "GIT STATUS"

--- a/gitops/azure-devops/unit_test/unit_test.sh
+++ b/gitops/azure-devops/unit_test/unit_test.sh
@@ -1,6 +1,8 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
+# shellcheck disable=SC1091
 . ../build.sh --source-only
+# shellcheck disable=SC1091
 . ./environment.properties
 
 oneTimeSetUp() {
@@ -9,7 +11,7 @@ oneTimeSetUp() {
     HELM_CHART_REPO=$HELM_CHART_REPO
     HELM_CHART_REPO_URL=$HELM_CHART_REPO_URL
     AKS_MANIFEST_REPO=$AKS_MANIFEST_REPO
-    VERSION_TO_DOWNLOAD=$VERSION
+    # VERSION_TO_DOWNLOAD=$VERSION
     PAT=$PAT
 }
 
@@ -24,7 +26,7 @@ testHelmInit() {
 
 testFabDownload() {
     ORIGINAL_PWD=$PWD
-    cd $HOME
+    cd "$HOME" || exit 1
 
     # Download Fabrikate example 
     cmd=" git clone https://github.com/Microsoft/fabrikate "
@@ -43,7 +45,7 @@ testFabDownload() {
     else
         assertTrue 1
     fi
-    cd fabrikate/examples/getting-started
+    cd fabrikate/examples/getting-started || exit 1
     export PATH=$PATH:$HOME/fab
 }
 
@@ -69,7 +71,7 @@ testFabGenerate() {
     else    
         assertTrue 1
     fi
-    cd $ORIGINAL_PWD
+    cd "$ORIGINAL_PWD" || exit 1
 }
 
 testGitConnection() {
@@ -101,15 +103,16 @@ testGitConnection() {
     repo_url=https://github.com/$AKS_MANIFEST_REPO.git
     repo=${repo_url##*/}
     repo_name=${repo%.*}
-    cd $repo_name
+    cd "$repo_name" || exit 1
 }
 
 # Tear down temporary resources
 oneTimeTearDown() {
     rm -rf fab*
-    rm -rf $HOME/fab*
-    rm -rf $ORIGINAL_PWD/$repo_name
+    rm -rf "$HOME/fab*"
+    rm -rf "${ORIGINAL_PWD:?}/$repo_name" # Avoids deleting / if ORIGINAL_PWD is empty.
 }
 
 # Execute shunit2 to run the tests
+# shellcheck disable=SC1091
 . ./shunit2/shunit2


### PR DESCRIPTION
There are many critical shell scripts in the repository so it would be wise to lint changes and PRs using an established linter like `shellcheck` to avoid introducing bugs. `shellcheck` comes pre-installed in the Ubuntu Build Agent so you just need to add it as a build step (see the yaml file) and fail on warnings/errors. 

In this PR, I fixed all the lint errors reported but it would be great for the initial shell script authors to review the changes. This PR is a nice to have and is low priority.