### PR TITLE
Make terraform version flexible in common provider.

### DIFF
--- a/cluster/common/provider/main.tf
+++ b/cluster/common/provider/main.tf
@@ -3,5 +3,5 @@ provider "null" {
 }
 
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = ">= 0.11.13, < 0.13"
 }


### PR DESCRIPTION
Consumers of this module (i.e., Cobalt via the backend-state module) who
leverage Terraform 0.12 recieve errors when trying to run the
out-of-the-box terraform 0.12 upgrade command because this module is
pinned to TF 0.11.13. This change will make it more usable across
different terraform versions