### PR TITLE
support BYO resource groups and don't delete them on destroy

### DIFF
--- a/cluster/azure/README-deploy-misc.md
+++ b/cluster/azure/README-deploy-misc.md
@@ -1,0 +1,21 @@
+# Azure Kubernetes Service Deployment Options
+
+Using Terraform to interact with Azure, there are options on how to manage one's deployments.  This document is a collection of those options that don't necessarily fit within other portions of the document.  Topics include:
+
+- [Using an Existing Resource Group](#using-an-existing-resource-group)
+
+## Using An Existing Resource Group
+
+Any object that is referred to as a `resource` in a Terraform script will be managed by Terraform and tracked as part of the `tfstate` file during deployment.  This means, if you were to use an existing `resource_group` as part of one of the environment deployments (for instance specifying the `resource_group_name` in [azure-simple](../environments/azure-simple/)) when one performed `terraform destroy`, Terraform will remove the specified resource group.
+
+In order to get around this, each of the Bedrock environments have been modified to allow for deployment into an existing `resource_group` without impacting that `resource group` upon the execution of `terraform destroy`.  In order to do this, each environment has a variable similar to the name `resource_group_preallocated`.  This value must be set to `true` in order to operate on an existing `resource group` without risking deletion of that `resource group` when destory operations are performed.  The name of the variable differs slightly per environment and in the case of environments with multiple resource groups, there will be a corresponding `*_preallocated` variable for each of the resource groups.
+
+So for instance, in the case of `azure-simple`, the relevant portion of the `terraform.tfvars` file for resource group definition would resemble:
+
+```bash
+resource_group_name="thisisanexistingresourcegroup"
+resource_group_preallocated="true"
+resource_group_location="westus2"
+```
+
+Note that `resource_group_location` is still specified, but this value will be ignored and the actual location of the existing resource group will be used.

--- a/cluster/azure/README.md
+++ b/cluster/azure/README.md
@@ -40,6 +40,8 @@ The common steps necessary to deploy a cluster are:
 - [Configure `kubectl` to see your new AKS cluster](#configure-kubectl-to-see-your-new-aks-cluster)
 - [Verify that your AKS cluster is healthy](#verify-that-your-aks-cluster-is-healthy)
 
+**NOTE**, in some cases there may be a need to follow slightly different deployment steps.  For instance, if one wanted to use an existing `resource group`.  These topics are covered [here](../README-deploy-misc.md).
+
 ### Create an Azure Service Principal
 
 You can generate an Azure Service Principal using the [`az ad sp create-for-rbac`](https://docs.microsoft.com/en-us/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create) command with `--skip-assignment` option. The `--skip-assignment` parameter limits any additional permissions from being assigned the default [`Contributor`](https://docs.microsoft.com/en-us/azure/role-based-access-control/rbac-and-directory-admin-roles#azure-rbac-roles) role in Azure subscription.

--- a/cluster/azure/README.md
+++ b/cluster/azure/README.md
@@ -40,7 +40,7 @@ The common steps necessary to deploy a cluster are:
 - [Configure `kubectl` to see your new AKS cluster](#configure-kubectl-to-see-your-new-aks-cluster)
 - [Verify that your AKS cluster is healthy](#verify-that-your-aks-cluster-is-healthy)
 
-**NOTE**, in some cases there may be a need to follow slightly different deployment steps.  For instance, if one wanted to use an existing `resource group`.  These topics are covered [here](../README-deploy-misc.md).
+**NOTE**, in some cases there may be a need to follow slightly different deployment steps.  For instance, if one wanted to use an existing `resource group`.  These topics are covered [here](./README-deploy-misc.md).
 
 ### Create an Azure Service Principal
 

--- a/cluster/azure/aks-gitops/main.tf
+++ b/cluster/azure/aks-gitops/main.tf
@@ -2,7 +2,6 @@ module "aks" {
   source = "../../azure/aks"
 
   resource_group_name      = "${var.resource_group_name}"
-  resource_group_location  = "${var.resource_group_location}"
   cluster_name             = "${var.cluster_name}"
   agent_vm_count           = "${var.agent_vm_count}"
   agent_vm_size            = "${var.agent_vm_size}"

--- a/cluster/azure/aks-gitops/variables.tf
+++ b/cluster/azure/aks-gitops/variables.tf
@@ -54,10 +54,6 @@ variable "resource_group_name" {
   type = "string"
 }
 
-variable "resource_group_location" {
-  type = "string"
-}
-
 variable "service_principal_id" {
   type = "string"
 }

--- a/cluster/azure/aks/main.tf
+++ b/cluster/azure/aks/main.tf
@@ -3,7 +3,7 @@ module "azure-provider" {
 }
 
 data "azurerm_resource_group" "cluster" {
-  name     = "${var.resource_group_name}"
+  name = "${var.resource_group_name}"
 }
 
 resource "azurerm_kubernetes_cluster" "cluster" {

--- a/cluster/azure/aks/main.tf
+++ b/cluster/azure/aks/main.tf
@@ -2,15 +2,14 @@ module "azure-provider" {
   source = "../provider"
 }
 
-resource "azurerm_resource_group" "cluster" {
+data "azurerm_resource_group" "cluster" {
   name     = "${var.resource_group_name}"
-  location = "${var.resource_group_location}"
 }
 
 resource "azurerm_kubernetes_cluster" "cluster" {
   name                = "${var.cluster_name}"
-  location            = "${azurerm_resource_group.cluster.location}"
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  location            = "${data.azurerm_resource_group.cluster.location}"
+  resource_group_name = "${data.azurerm_resource_group.cluster.name}"
   dns_prefix          = "${var.dns_prefix}"
   kubernetes_version  = "${var.kubernetes_version}"
 

--- a/cluster/azure/aks/variables.tf
+++ b/cluster/azure/aks/variables.tf
@@ -1,7 +1,3 @@
-variable "resource_group_location" {
-  type = "string"
-}
-
 variable "resource_group_name" {
   type = "string"
 }

--- a/cluster/azure/keyvault/main.tf
+++ b/cluster/azure/keyvault/main.tf
@@ -3,7 +3,7 @@ module "azure-provider" {
 }
 
 data "azurerm_resource_group" "keyvault" {
-  name     = "${var.resource_group_name}"
+  name = "${var.resource_group_name}"
 }
 
 data "azurerm_client_config" "current" {}

--- a/cluster/azure/keyvault/main.tf
+++ b/cluster/azure/keyvault/main.tf
@@ -2,17 +2,16 @@ module "azure-provider" {
   source = "../provider"
 }
 
-resource "azurerm_resource_group" "keyvault" {
+data "azurerm_resource_group" "keyvault" {
   name     = "${var.resource_group_name}"
-  location = "${var.location}"
 }
 
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "keyvault" {
   name                = "${var.keyvault_name}"
-  location            = "${azurerm_resource_group.keyvault.location}"
-  resource_group_name = "${azurerm_resource_group.keyvault.name}"
+  location            = "${data.azurerm_resource_group.keyvault.location}"
+  resource_group_name = "${data.azurerm_resource_group.keyvault.name}"
   tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
 
   sku {

--- a/cluster/azure/keyvault/variables.tf
+++ b/cluster/azure/keyvault/variables.tf
@@ -12,8 +12,3 @@ variable "resource_group_name" {
   description = "Default resource group name that the network will be created in."
   default     = "myapp-rg"
 }
-
-variable "location" {
-  description = "The location/region where the core network will be created. The full list of Azure regions can be found at https://azure.microsoft.com/regions"
-  type        = "string"
-}

--- a/cluster/azure/tm-endpoint-ip/main.tf
+++ b/cluster/azure/tm-endpoint-ip/main.tf
@@ -1,5 +1,5 @@
 data "azurerm_resource_group" "pip" {
-  name                = "${var.resource_group_name}"
+  name = "${var.resource_group_name}"
 }
 
 resource "azurerm_public_ip" "pip" {

--- a/cluster/azure/tm-endpoint-ip/main.tf
+++ b/cluster/azure/tm-endpoint-ip/main.tf
@@ -1,7 +1,11 @@
+data "azurerm_resource_group" "pip" {
+  name                = "${var.resource_group_name}"
+}
+
 resource "azurerm_public_ip" "pip" {
   name                = "${var.public_ip_name}-ip"
-  location            = "${var.resource_location}"
-  resource_group_name = "${var.resource_group_name}"
+  location            = "${data.azurerm_resource_group.pip.location}"
+  resource_group_name = "${data.azurerm_resource_group.pip.name}"
   allocation_method   = "Static"
   domain_name_label   = "${var.public_ip_name}-dns"
   tags                = "${var.tags}"

--- a/cluster/azure/tm-endpoint-ip/variables.tf
+++ b/cluster/azure/tm-endpoint-ip/variables.tf
@@ -18,10 +18,6 @@ variable "resource_group_name" {
   type = "string"
 }
 
-variable "resource_location" {
-  type = "string"
-}
-
 variable "ip_address_out_filename" {
   type    = "string"
   default = "bedrock_public_ip_address"

--- a/cluster/azure/vnet/main.tf
+++ b/cluster/azure/vnet/main.tf
@@ -1,5 +1,5 @@
 data "azurerm_resource_group" "vnet" {
-  name     = "${var.resource_group_name}"
+  name = "${var.resource_group_name}"
 }
 
 resource "azurerm_virtual_network" "vnet" {

--- a/cluster/azure/vnet/main.tf
+++ b/cluster/azure/vnet/main.tf
@@ -1,13 +1,12 @@
-resource "azurerm_resource_group" "vnet" {
+data "azurerm_resource_group" "vnet" {
   name     = "${var.resource_group_name}"
-  location = "${var.resource_group_location}"
 }
 
 resource "azurerm_virtual_network" "vnet" {
   name                = "${var.vnet_name}"
-  location            = "${azurerm_resource_group.vnet.location}"
+  location            = "${data.azurerm_resource_group.vnet.location}"
   address_space       = ["${var.address_space}"]
-  resource_group_name = "${azurerm_resource_group.vnet.name}"
+  resource_group_name = "${data.azurerm_resource_group.vnet.name}"
   dns_servers         = "${var.dns_servers}"
   tags                = "${var.tags}"
 }
@@ -16,7 +15,7 @@ resource "azurerm_subnet" "subnet" {
   count                = "${length(var.subnet_names)}"
   name                 = "${var.subnet_names[count.index]}"
   virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-  resource_group_name  = "${azurerm_resource_group.vnet.name}"
+  resource_group_name  = "${data.azurerm_resource_group.vnet.name}"
 
   address_prefix    = "${var.subnet_prefixes[count.index]}"
   service_endpoints = "${split(",",var.subnet_service_endpoints[count.index])}"

--- a/cluster/azure/vnet/variables.tf
+++ b/cluster/azure/vnet/variables.tf
@@ -8,10 +8,6 @@ variable "resource_group_name" {
   default     = "myapp-rg"
 }
 
-variable "resource_group_location" {
-  description = "Default resource group location that the resource group will be created in. The full list of Azure regions can be found at https://azure.microsoft.com/regions"
-}
-
 variable "address_space" {
   description = "The address space that is used by the virtual network."
   default     = "10.10.0.0/16"

--- a/cluster/common/provider/main.tf
+++ b/cluster/common/provider/main.tf
@@ -3,5 +3,5 @@ provider "null" {
 }
 
 terraform {
-  required_version = "~> 0.11.13"
+  required_version = "~> 0.11"
 }

--- a/cluster/environments/azure-common-infra/keyvault.tf
+++ b/cluster/environments/azure-common-infra/keyvault.tf
@@ -1,15 +1,16 @@
 data "azurerm_client_config" "current" {}
 
 module "keyvault" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/keyvault"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/keyvault"
+  source = "../../azure/keyvault"
 
   keyvault_name       = "${var.keyvault_name}"
-  resource_group_name = "${var.global_resource_group_name}"
-  location            = "${var.global_resource_group_location}"
+  resource_group_name = "${data.azurerm_resource_group.global_rg.name}"
 }
 
 module "keyvault_access_policy_default" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_policy"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_policy"
+  source = "../../azure/keyvault_policy"
 
   vault_id  = "${module.keyvault.keyvault_id}"
   tenant_id = "${data.azurerm_client_config.current.tenant_id}"
@@ -17,7 +18,8 @@ module "keyvault_access_policy_default" {
 }
 
 module "keyvault_access_policy_aks" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_policy"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_policy"
+  source = "../../azure/keyvault_policy"
 
   vault_id           = "${module.keyvault.keyvault_id}"
   tenant_id          = "${data.azurerm_client_config.current.tenant_id}"

--- a/cluster/environments/azure-common-infra/main.tf
+++ b/cluster/environments/azure-common-infra/main.tf
@@ -1,12 +1,18 @@
-terraform {
-  backend "azurerm" {}
-}
+#terraform {
+#  backend "azurerm" {}
+#}
 
 module "provider" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/provider"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/provider"
+  source = "../../azure/provider"
 }
 
 resource "azurerm_resource_group" "global_rg" {
+  count    = "${var.global_resource_group_preallocated ? 0 : 1}"
   name     = "${var.global_resource_group_name}"
   location = "${var.global_resource_group_location}"
+}
+
+data "azurerm_resource_group" "global_rg" {
+  name     = "${var.global_resource_group_preallocated ? var.global_resource_group_name : join("", azurerm_resource_group.global_rg.*.name)}"
 }

--- a/cluster/environments/azure-common-infra/main.tf
+++ b/cluster/environments/azure-common-infra/main.tf
@@ -1,6 +1,6 @@
-#terraform {
-#  backend "azurerm" {}
-#}
+terraform {
+  backend "azurerm" {}
+}
 
 module "provider" {
   #source = "github.com/Microsoft/bedrock/cluster/azure/provider"

--- a/cluster/environments/azure-common-infra/main.tf
+++ b/cluster/environments/azure-common-infra/main.tf
@@ -14,5 +14,5 @@ resource "azurerm_resource_group" "global_rg" {
 }
 
 data "azurerm_resource_group" "global_rg" {
-  name     = "${var.global_resource_group_preallocated ? var.global_resource_group_name : join("", azurerm_resource_group.global_rg.*.name)}"
+  name = "${var.global_resource_group_preallocated ? var.global_resource_group_name : join("", azurerm_resource_group.global_rg.*.name)}"
 }

--- a/cluster/environments/azure-common-infra/variables.tf
+++ b/cluster/environments/azure-common-infra/variables.tf
@@ -14,6 +14,11 @@ variable "global_resource_group_location" {
   type = "string"
 }
 
+variable "global_resource_group_preallocated" {
+  description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
+  default = false
+}
+
 variable "service_principal_id" {
   type = "string"
 }

--- a/cluster/environments/azure-common-infra/variables.tf
+++ b/cluster/environments/azure-common-infra/variables.tf
@@ -16,7 +16,7 @@ variable "global_resource_group_location" {
 
 variable "global_resource_group_preallocated" {
   description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
-  default = false
+  default     = false
 }
 
 variable "service_principal_id" {

--- a/cluster/environments/azure-common-infra/vnet.tf
+++ b/cluster/environments/azure-common-infra/vnet.tf
@@ -1,13 +1,13 @@
 module "vnet" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
+  source = "../../azure/vnet"
 
   vnet_name = "${var.vnet_name}"
 
   address_space   = "${var.address_space}"
   subnet_prefixes = ["${var.subnet_prefix}"]
 
-  resource_group_name     = "${azurerm_resource_group.global_rg.name}"
-  resource_group_location = "${azurerm_resource_group.global_rg.location}"
+  resource_group_name     = "${data.azurerm_resource_group.global_rg.name}"
   subnet_names            = ["${var.subnet_name}"]
 }
 

--- a/cluster/environments/azure-common-infra/vnet.tf
+++ b/cluster/environments/azure-common-infra/vnet.tf
@@ -7,8 +7,8 @@ module "vnet" {
   address_space   = "${var.address_space}"
   subnet_prefixes = ["${var.subnet_prefix}"]
 
-  resource_group_name     = "${data.azurerm_resource_group.global_rg.name}"
-  subnet_names            = ["${var.subnet_name}"]
+  resource_group_name = "${data.azurerm_resource_group.global_rg.name}"
+  subnet_names        = ["${var.subnet_name}"]
 }
 
 //Used for integration test to automate providing vnet_subnet_ids to separate environments for aks clusters

--- a/cluster/environments/azure-multiple-clusters/aks-centralus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-centralus-variables.tf
@@ -6,6 +6,11 @@ variable "central_resource_group_location" {
   type = "string"
 }
 
+variable "central_resource_group_preallocated" {
+  description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
+  default = false
+}
+
 variable "gitops_central_path" {
   type = "string"
 }

--- a/cluster/environments/azure-multiple-clusters/aks-centralus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-centralus-variables.tf
@@ -8,7 +8,7 @@ variable "central_resource_group_location" {
 
 variable "central_resource_group_preallocated" {
   description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
-  default = false
+  default     = false
 }
 
 variable "gitops_central_path" {

--- a/cluster/environments/azure-multiple-clusters/aks-centralus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-centralus.tf
@@ -1,11 +1,11 @@
 resource "azurerm_resource_group" "centralrg" {
-  count    = "${var.central_resource_group_preallocated ? 0 : 1}"  
+  count    = "${var.central_resource_group_preallocated ? 0 : 1}"
   name     = "${var.central_resource_group_name}"
   location = "${var.central_resource_group_location}"
 }
 
 data "azurerm_resource_group" "centralrg" {
-  name     = "${var.central_resource_group_preallocated ? var.central_resource_group_name : join("", azurerm_resource_group.centralrg.*.name)}"
+  name = "${var.central_resource_group_preallocated ? var.central_resource_group_name : join("", azurerm_resource_group.centralrg.*.name)}"
 }
 
 # local variable with cluster and location specific
@@ -23,10 +23,10 @@ module "central_vnet" {
   #source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
   source = "../../azure/vnet"
 
-  resource_group_name     = "${local.central_rg_name }"
-  subnet_names            = ["${var.cluster_name}_aks_subnet"]
-  address_space           = "${var.central_address_space}"
-  subnet_prefixes         = "${var.central_subnet_prefixes}"
+  resource_group_name = "${local.central_rg_name }"
+  subnet_names        = ["${var.cluster_name}_aks_subnet"]
+  address_space       = "${var.central_address_space}"
+  subnet_prefixes     = "${var.central_subnet_prefixes}"
 
   tags = {
     environment = "azure_multiple_clusters"

--- a/cluster/environments/azure-multiple-clusters/aks-eastus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus-variables.tf
@@ -6,6 +6,11 @@ variable "east_resource_group_location" {
   type = "string"
 }
 
+variable "east_resource_group_preallocated" {
+  description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
+  default = false
+}
+
 variable "gitops_east_path" {
   type = "string"
 }

--- a/cluster/environments/azure-multiple-clusters/aks-eastus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus-variables.tf
@@ -8,7 +8,7 @@ variable "east_resource_group_location" {
 
 variable "east_resource_group_preallocated" {
   description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
-  default = false
+  default     = false
 }
 
 variable "gitops_east_path" {

--- a/cluster/environments/azure-multiple-clusters/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus.tf
@@ -1,12 +1,17 @@
 resource "azurerm_resource_group" "eastrg" {
+  count    = "${var.east_resource_group_preallocated ? 0 : 1}"  
   name     = "${var.east_resource_group_name}"
   location = "${var.east_resource_group_location}"
 }
 
+data "azurerm_resource_group" "eastrg" {
+  name     = "${var.east_resource_group_preallocated ? var.east_resource_group_name : join("", azurerm_resource_group.eastrg.*.name)}"
+}
+
 # local variable with cluster and location specific
 locals {
-  east_rg_name                 = "${azurerm_resource_group.eastrg.name}"
-  east_rg_location             = "${azurerm_resource_group.eastrg.location}"
+  east_rg_name                 = "${data.azurerm_resource_group.eastrg.name}"
+  east_rg_location             = "${data.azurerm_resource_group.eastrg.location}"
   east_prefix                  = "${local.east_rg_location}_${var.cluster_name}"
   east_flux_clone_dir          = "${local.east_prefix}_flux"
   east_kubeconfig_filename     = "${local.east_prefix}_kube_config"
@@ -15,10 +20,10 @@ locals {
 
 # Creates east vnet
 module "east_vnet" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
+  source = "../../azure/vnet"
 
-  resource_group_name     = "${local.east_rg_name }"
-  resource_group_location = "${local.east_rg_location}"
+  resource_group_name     = "${local.east_rg_name}"
   subnet_names            = ["${var.cluster_name}_aks_subnet"]
   address_space           = "${var.east_address_space}"
   subnet_prefixes         = "${var.east_subnet_prefixes}"
@@ -30,7 +35,8 @@ module "east_vnet" {
 
 # Creates east aks cluster, flux, kubediff
 module "east_aks_gitops" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/aks-gitops"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"
@@ -43,8 +49,7 @@ module "east_aks_gitops" {
   gitops_path              = "${var.gitops_east_path}"
   gitops_url_branch        = "${var.gitops_east_url_branch}"
   gitops_poll_interval     = "${var.gitops_poll_interval}"
-  resource_group_location  = "${var.east_resource_group_location}"
-  resource_group_name      = "${azurerm_resource_group.eastrg.name}"
+  resource_group_name      = "${local.east_rg_name}"
   service_cidr             = "${var.east_service_cidr}"
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"
@@ -57,11 +62,11 @@ module "east_aks_gitops" {
 
 # create a static public ip and associate with traffic manger endpoint
 module "east_tm_endpoint" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/tm-endpoint-ip"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/tm-endpoint-ip"
+  source = "../../azure/tm-endpoint-ip"
 
   resource_group_name                 = "${local.east_rg_name}"
-  resource_location                   = "${local.east_rg_location}"
-  traffic_manager_resource_group_name = "${var.traffic_manager_resource_group_name}"
+  traffic_manager_resource_group_name = "${data.azurerm_resource_group.tmrg.name}"
   traffic_manager_profile_name        = "${var.traffic_manager_profile_name}"
   endpoint_name                       = "${local.east_rg_location}_${var.cluster_name}"
   public_ip_name                      = "${var.cluster_name}"
@@ -78,12 +83,13 @@ module "east_tm_endpoint" {
 resource "azurerm_role_assignment" "east_spra" {
   principal_id         = "${data.azuread_service_principal.sp.id}"
   role_definition_name = "${var.aks_client_role_assignment_role}"
-  scope                = "${azurerm_resource_group.eastrg.id}"
+  scope                = "${data.azurerm_resource_group.eastrg.id}"
 }
 
 # Deploy east keyvault flexvolume
 module "east_flex_volume" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_flexvol"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_flexvol"
+  source = "../../azure/keyvault_flexvol"
 
   resource_group_name      = "${var.keyvault_resource_group}"
   service_principal_id     = "${var.service_principal_id}"

--- a/cluster/environments/azure-multiple-clusters/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus.tf
@@ -1,11 +1,11 @@
 resource "azurerm_resource_group" "eastrg" {
-  count    = "${var.east_resource_group_preallocated ? 0 : 1}"  
+  count    = "${var.east_resource_group_preallocated ? 0 : 1}"
   name     = "${var.east_resource_group_name}"
   location = "${var.east_resource_group_location}"
 }
 
 data "azurerm_resource_group" "eastrg" {
-  name     = "${var.east_resource_group_preallocated ? var.east_resource_group_name : join("", azurerm_resource_group.eastrg.*.name)}"
+  name = "${var.east_resource_group_preallocated ? var.east_resource_group_name : join("", azurerm_resource_group.eastrg.*.name)}"
 }
 
 # local variable with cluster and location specific
@@ -23,10 +23,10 @@ module "east_vnet" {
   #source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
   source = "../../azure/vnet"
 
-  resource_group_name     = "${local.east_rg_name}"
-  subnet_names            = ["${var.cluster_name}_aks_subnet"]
-  address_space           = "${var.east_address_space}"
-  subnet_prefixes         = "${var.east_subnet_prefixes}"
+  resource_group_name = "${local.east_rg_name}"
+  subnet_names        = ["${var.cluster_name}_aks_subnet"]
+  address_space       = "${var.east_address_space}"
+  subnet_prefixes     = "${var.east_subnet_prefixes}"
 
   tags = {
     environment = "azure_multiple_clusters"

--- a/cluster/environments/azure-multiple-clusters/aks-westus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus-variables.tf
@@ -8,7 +8,7 @@ variable "west_resource_group_location" {
 
 variable "west_resource_group_preallocated" {
   description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
-  default = false
+  default     = false
 }
 
 variable "gitops_west_path" {

--- a/cluster/environments/azure-multiple-clusters/aks-westus-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus-variables.tf
@@ -6,6 +6,11 @@ variable "west_resource_group_location" {
   type = "string"
 }
 
+variable "west_resource_group_preallocated" {
+  description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
+  default = false
+}
+
 variable "gitops_west_path" {
   type = "string"
 }

--- a/cluster/environments/azure-multiple-clusters/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus.tf
@@ -1,11 +1,11 @@
 resource "azurerm_resource_group" "westrg" {
-  count    = "${var.west_resource_group_preallocated ? 0 : 1}"  
+  count    = "${var.west_resource_group_preallocated ? 0 : 1}"
   name     = "${var.west_resource_group_name}"
   location = "${var.west_resource_group_location}"
 }
 
 data "azurerm_resource_group" "westrg" {
-  name     = "${var.west_resource_group_preallocated ? var.west_resource_group_name : join("", azurerm_resource_group.westrg.*.name)}"
+  name = "${var.west_resource_group_preallocated ? var.west_resource_group_name : join("", azurerm_resource_group.westrg.*.name)}"
 }
 
 # local variable with cluster and location specific
@@ -23,10 +23,10 @@ module "west_vnet" {
   #source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
   source = "../../azure/vnet"
 
-  resource_group_name     = "${local.west_rg_name}"
-  subnet_names            = ["${var.cluster_name}_aks_subnet"]
-  address_space           = "${var.west_address_space}"
-  subnet_prefixes         = "${var.west_subnet_prefixes}"
+  resource_group_name = "${local.west_rg_name}"
+  subnet_names        = ["${var.cluster_name}_aks_subnet"]
+  address_space       = "${var.west_address_space}"
+  subnet_prefixes     = "${var.west_subnet_prefixes}"
 
   tags = {
     environment = "azure_multiple_clusters"

--- a/cluster/environments/azure-multiple-clusters/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus.tf
@@ -1,12 +1,17 @@
 resource "azurerm_resource_group" "westrg" {
+  count    = "${var.west_resource_group_preallocated ? 0 : 1}"  
   name     = "${var.west_resource_group_name}"
   location = "${var.west_resource_group_location}"
 }
 
+data "azurerm_resource_group" "westrg" {
+  name     = "${var.west_resource_group_preallocated ? var.west_resource_group_name : join("", azurerm_resource_group.westrg.*.name)}"
+}
+
 # local variable with cluster and location specific
 locals {
-  west_rg_name                 = "${azurerm_resource_group.westrg.name}"
-  west_rg_location             = "${azurerm_resource_group.westrg.location}"
+  west_rg_name                 = "${data.azurerm_resource_group.westrg.name}"
+  west_rg_location             = "${data.azurerm_resource_group.westrg.location}"
   west_prefix                  = "${local.west_rg_location}_${var.cluster_name}"
   west_flux_clone_dir          = "${local.west_prefix}_flux"
   west_kubeconfig_filename     = "${local.west_prefix}_kube_config"
@@ -15,10 +20,10 @@ locals {
 
 # Creates west vnet
 module "west_vnet" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
+  source = "../../azure/vnet"
 
   resource_group_name     = "${local.west_rg_name}"
-  resource_group_location = "${local.west_rg_location}"
   subnet_names            = ["${var.cluster_name}_aks_subnet"]
   address_space           = "${var.west_address_space}"
   subnet_prefixes         = "${var.west_subnet_prefixes}"
@@ -30,7 +35,8 @@ module "west_vnet" {
 
 # Creates west aks cluster, flux, kubediff
 module "west_aks_gitops" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/aks-gitops"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"
@@ -43,8 +49,7 @@ module "west_aks_gitops" {
   gitops_path              = "${var.gitops_west_path}"
   gitops_url_branch        = "${var.gitops_west_url_branch}"
   gitops_poll_interval     = "${var.gitops_poll_interval}"
-  resource_group_location  = "${var.west_resource_group_location}"
-  resource_group_name      = "${azurerm_resource_group.westrg.name}"
+  resource_group_name      = "${local.west_rg_name}"
   service_cidr             = "${var.west_service_cidr}"
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"
@@ -57,11 +62,11 @@ module "west_aks_gitops" {
 
 # create a static public ip and associate with traffic manger endpoint
 module "west_tm_endpoint" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/tm-endpoint-ip"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/tm-endpoint-ip"
+  source = "../../azure/tm-endpoint-ip"
 
   resource_group_name                 = "${local.west_rg_name}"
-  resource_location                   = "${local.west_rg_location}"
-  traffic_manager_resource_group_name = "${var.traffic_manager_resource_group_name}"
+  traffic_manager_resource_group_name = "${data.azurerm_resource_group.tmrg.name}"
   traffic_manager_profile_name        = "${var.traffic_manager_profile_name}"
   endpoint_name                       = "${local.west_rg_location}_${var.cluster_name}"
   public_ip_name                      = "${var.cluster_name}"
@@ -78,12 +83,13 @@ module "west_tm_endpoint" {
 resource "azurerm_role_assignment" "west_spra" {
   principal_id         = "${data.azuread_service_principal.sp.id}"
   role_definition_name = "${var.aks_client_role_assignment_role}"
-  scope                = "${azurerm_resource_group.westrg.id}"
+  scope                = "${data.azurerm_resource_group.westrg.id}"
 }
 
 # Deploy west keyvault flexvolume
 module "west_flex_volume" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_flexvol"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_flexvol"
+  source = "../../azure/keyvault_flexvol"
 
   resource_group_name      = "${var.keyvault_resource_group}"
   service_principal_id     = "${var.service_principal_id}"

--- a/cluster/environments/azure-multiple-clusters/main.tf
+++ b/cluster/environments/azure-multiple-clusters/main.tf
@@ -1,5 +1,6 @@
 module "provider" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/provider"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/provider"
+  source = "../../azure/provider"
 }
 
 # Read AKS cluster service principal (client) object to create a role assignment
@@ -11,7 +12,8 @@ data "azurerm_client_config" "current" {}
 
 # Create Azure Key Vault role for SP
 module "keyvault_flexvolume_role" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_flexvol_role"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/keyvault_flexvol_role"
+  source = "../../azure/keyvault_flexvol_role"
 
   resource_group_name  = "${var.keyvault_resource_group}"
   service_principal_id = "${var.service_principal_id}"

--- a/cluster/environments/azure-multiple-clusters/trafficmanager-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/trafficmanager-variables.tf
@@ -6,6 +6,11 @@ variable "traffic_manager_resource_group_location" {
   type = "string"
 }
 
+variable "traffic_manager_resource_group_preallocated" {
+  description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
+  default = false
+}
+
 variable "traffic_manager_profile_name" {
   type = "string"
 }

--- a/cluster/environments/azure-multiple-clusters/trafficmanager-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/trafficmanager-variables.tf
@@ -8,7 +8,7 @@ variable "traffic_manager_resource_group_location" {
 
 variable "traffic_manager_resource_group_preallocated" {
   description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
-  default = false
+  default     = false
 }
 
 variable "traffic_manager_profile_name" {

--- a/cluster/environments/azure-multiple-clusters/trafficmanager.tf
+++ b/cluster/environments/azure-multiple-clusters/trafficmanager.tf
@@ -1,13 +1,19 @@
 resource "azurerm_resource_group" "tmrg" {
+  count    = "${var.traffic_manager_resource_group_preallocated ? 0 : 1}"  
   name     = "${var.traffic_manager_resource_group_name}"
   location = "${var.traffic_manager_resource_group_location}"
 }
 
+data "azurerm_resource_group" "tmrg" {
+  name     = "${var.traffic_manager_resource_group_preallocated ? var.traffic_manager_resource_group_name : join("", azurerm_resource_group.tmrg.*.name)}"
+}
+
 module "trafficmanager" {
+  #source = "github.com/Microsoft/bedrock/cluster/azure/tm-profile"
   source = "../../azure/tm-profile"
 
-  resource_group_name              = "${azurerm_resource_group.tmrg.name}"
-  resource_group_location          = "${azurerm_resource_group.tmrg.location}"
+  resource_group_name              = "${data.azurerm_resource_group.tmrg.name}"
+  resource_group_location          = "${data.azurerm_resource_group.tmrg.location}"
   traffic_manager_profile_name     = "${var.traffic_manager_profile_name}"
   traffic_manager_dns_name         = "${var.traffic_manager_dns_name}"
   traffic_manager_monitor_protocol = "${var.traffic_manager_monitor_protocol}"

--- a/cluster/environments/azure-multiple-clusters/trafficmanager.tf
+++ b/cluster/environments/azure-multiple-clusters/trafficmanager.tf
@@ -1,11 +1,11 @@
 resource "azurerm_resource_group" "tmrg" {
-  count    = "${var.traffic_manager_resource_group_preallocated ? 0 : 1}"  
+  count    = "${var.traffic_manager_resource_group_preallocated ? 0 : 1}"
   name     = "${var.traffic_manager_resource_group_name}"
   location = "${var.traffic_manager_resource_group_location}"
 }
 
 data "azurerm_resource_group" "tmrg" {
-  name     = "${var.traffic_manager_resource_group_preallocated ? var.traffic_manager_resource_group_name : join("", azurerm_resource_group.tmrg.*.name)}"
+  name = "${var.traffic_manager_resource_group_preallocated ? var.traffic_manager_resource_group_name : join("", azurerm_resource_group.tmrg.*.name)}"
 }
 
 module "trafficmanager" {

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -10,18 +10,18 @@ resource "azurerm_resource_group" "cluster_rg" {
 }
 
 data "azurerm_resource_group" "cluster_rg" {
-  name     = "${var.resource_group_preallocated ? var.resource_group_name : join("", azurerm_resource_group.cluster_rg.*.name)}"
+  name = "${var.resource_group_preallocated ? var.resource_group_name : join("", azurerm_resource_group.cluster_rg.*.name)}"
 }
 
 module "vnet" {
   #source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
   source = "../../azure/vnet"
 
-  vnet_name               = "${var.vnet_name}"
-  address_space           = "${var.address_space}"
-  resource_group_name     = "${data.azurerm_resource_group.cluster_rg.name}"
-  subnet_names            = ["${var.cluster_name}-aks-subnet"]
-  subnet_prefixes         = "${var.subnet_prefixes}"
+  vnet_name           = "${var.vnet_name}"
+  address_space       = "${var.address_space}"
+  resource_group_name = "${data.azurerm_resource_group.cluster_rg.name}"
+  subnet_names        = ["${var.cluster_name}-aks-subnet"]
+  subnet_prefixes     = "${var.subnet_prefixes}"
 
   tags = {
     environment = "azure-simple"

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -1,19 +1,25 @@
 module "provider" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/provider"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/provider"
+  source = "../../azure/provider"
 }
 
 resource "azurerm_resource_group" "cluster_rg" {
+  count    = "${var.resource_group_preallocated ? 0 : 1}"
   name     = "${var.resource_group_name}"
   location = "${var.resource_group_location}"
 }
 
+data "azurerm_resource_group" "cluster_rg" {
+  name     = "${var.resource_group_preallocated ? var.resource_group_name : join("", azurerm_resource_group.cluster_rg.*.name)}"
+}
+
 module "vnet" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/vnet"
+  source = "../../azure/vnet"
 
   vnet_name               = "${var.vnet_name}"
   address_space           = "${var.address_space}"
-  resource_group_name     = "${var.resource_group_name}"
-  resource_group_location = "${var.resource_group_location}"
+  resource_group_name     = "${data.azurerm_resource_group.cluster_rg.name}"
   subnet_names            = ["${var.cluster_name}-aks-subnet"]
   subnet_prefixes         = "${var.subnet_prefixes}"
 
@@ -23,7 +29,8 @@ module "vnet" {
 }
 
 module "aks-gitops" {
-  source = "github.com/Microsoft/bedrock/cluster/azure/aks-gitops"
+  #source = "github.com/Microsoft/bedrock/cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"
@@ -38,8 +45,7 @@ module "aks-gitops" {
   gitops_poll_interval     = "${var.gitops_poll_interval}"
   gitops_url_branch        = "${var.gitops_url_branch}"
   ssh_public_key           = "${var.ssh_public_key}"
-  resource_group_location  = "${var.resource_group_location}"
-  resource_group_name      = "${azurerm_resource_group.cluster_rg.name}"
+  resource_group_name      = "${data.azurerm_resource_group.cluster_rg.name}"
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"
   vnet_subnet_id           = "${module.vnet.vnet_subnet_ids[0]}"

--- a/cluster/environments/azure-simple/variables.tf
+++ b/cluster/environments/azure-simple/variables.tf
@@ -61,7 +61,7 @@ variable "resource_group_location" {
 
 variable "resource_group_preallocated" {
   description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
-  default = false
+  default     = false
 }
 
 variable "ssh_public_key" {

--- a/cluster/environments/azure-simple/variables.tf
+++ b/cluster/environments/azure-simple/variables.tf
@@ -59,6 +59,11 @@ variable "resource_group_location" {
   type = "string"
 }
 
+variable "resource_group_preallocated" {
+  description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
+  default = false
+}
+
 variable "ssh_public_key" {
   type = "string"
 }

--- a/cluster/environments/azure-single-keyvault/main.tf
+++ b/cluster/environments/azure-single-keyvault/main.tf
@@ -5,13 +5,14 @@
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "cluster_rg" {
-  count    = "${var.resource_group_preallocated ? 0 : 1}"  
+  count    = "${var.resource_group_preallocated ? 0 : 1}"
   name     = "${var.resource_group_name}"
   location = "${var.resource_group_location}"
 }
 
 data "azurerm_resource_group" "cluster_rg" {
-  name     = "${var.resource_group_preallocated ? var.resource_group_name : join("", azurerm_resource_group.cluster_rg.*.name)}"}
+  name = "${var.resource_group_preallocated ? var.resource_group_name : join("", azurerm_resource_group.cluster_rg.*.name)}"
+}
 
 module "aks-gitops" {
   #source = "github.com/Microsoft/bedrock/cluster/azure/aks-gitops"

--- a/cluster/environments/azure-single-keyvault/main.tf
+++ b/cluster/environments/azure-single-keyvault/main.tf
@@ -1,6 +1,6 @@
-#terraform {
-#  backend "azurerm" {}
-#}
+terraform {
+  backend "azurerm" {}
+}
 
 data "azurerm_client_config" "current" {}
 

--- a/cluster/environments/azure-single-keyvault/variables.tf
+++ b/cluster/environments/azure-single-keyvault/variables.tf
@@ -76,7 +76,7 @@ variable "resource_group_location" {
 
 variable "resource_group_preallocated" {
   description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
-  default = false
+  default     = false
 }
 
 variable "ssh_public_key" {

--- a/cluster/environments/azure-single-keyvault/variables.tf
+++ b/cluster/environments/azure-single-keyvault/variables.tf
@@ -74,6 +74,11 @@ variable "resource_group_location" {
   type = "string"
 }
 
+variable "resource_group_preallocated" {
+  description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
+  default = false
+}
+
 variable "ssh_public_key" {
   type = "string"
 }

--- a/cluster/environments/azure-velero-restore/main.tf
+++ b/cluster/environments/azure-velero-restore/main.tf
@@ -9,13 +9,13 @@ module "common-provider" {
 }
 
 resource "azurerm_resource_group" "cluster_rg" {
-  count    = "${var.resource_group_preallocated ? 0 : 1}"  
+  count    = "${var.resource_group_preallocated ? 0 : 1}"
   name     = "${var.resource_group_name}"
   location = "${var.resource_group_location}"
 }
 
 data "azurerm_resource_group" "cluster_rg" {
-  name     = "${var.resource_group_preallocated ? var.resource_group_name : join("", azurerm_resource_group.cluster_rg.*.name)}"
+  name = "${var.resource_group_preallocated ? var.resource_group_name : join("", azurerm_resource_group.cluster_rg.*.name)}"
 }
 
 resource "null_resource" "cloud_credentials" {

--- a/cluster/environments/azure-velero-restore/variables.tf
+++ b/cluster/environments/azure-velero-restore/variables.tf
@@ -79,6 +79,11 @@ variable "resource_group_location" {
   type = "string"
 }
 
+variable "resource_group_preallocated" {
+  description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
+  default = false
+}
+
 variable "ssh_public_key" {
   type = "string"
 }

--- a/cluster/environments/azure-velero-restore/variables.tf
+++ b/cluster/environments/azure-velero-restore/variables.tf
@@ -81,7 +81,7 @@ variable "resource_group_location" {
 
 variable "resource_group_preallocated" {
   description = "boolean value that when set to true, the specified resource group is assumed to exist.  it will not be feleted.  when set to false, the resource group will be 'managed' by Terraform and deleted on a 'terraform destroy'"
-  default = false
+  default     = false
 }
 
 variable "ssh_public_key" {


### PR DESCRIPTION
This PR addresses #474 ... It adds the ability for using your own resource group in deployments.  Additionally, resource group creation has been moved specifically to the environments rather than within modules themselves.  Modules reference the resource_group as a data item rather than a resource.  This way, the creation or reference of an existing resource group is isolated to the environments.

Documentation updates are required for this (in progress).

The reason for not using the TF `prevent_destroy` flag is discussed in https://github.com/microsoft/bedrock/issues/474 -- specifically, the RG could still be destroyed based on the following:  https://github.com/hashicorp/terraform/issues/17599

I'll post a comment when the documentation is updated.