### PR TITLE
WIP - updates to cluster creation docs

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -4,17 +4,17 @@ Bedrock automates Kubernetes cluster deployments with Terraform to provide full 
 
 ## Required Tools
 
-Bedrock uses three tools to automate cluster deployments that you'll need to install if you don't already have them:
+Bedrock assumes that you have a deployment computer or VM running Unix or Linux and a bash shell. Beyond that, it uses three main tools to automate cluster deployments that you'll need to install if you don't already have them:
 
-- [terraform](https://www.terraform.io/intro/getting-started/install.html)
+- [terraform v0.11.14](https://releases.hashicorp.com/terraform/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- [helm](https://github.com/helm/helm)
+- [helm](https://helm.sh/docs/using_helm/#installing-helm)
 
-Verify that these tools are added to your system's PATH in order to avoid errors during cluster deployment.  (Note to WSL users: You will need to either move the executables to /usr/local/bin, or modify ~/.bashrc to add them to PATH and persist the new additions across restarts.)
+Terraform v0.12 is not supported yet, so ensure that your environment has v0.11. Please do not install these packages with `snap` or other package installers - they can create issues when using `sudo`. Follow the instructions to use `curl` for all of them. Verify that these tools are added to your deployment system's PATH by printing your path or typing their names in the console in order to avoid errors during cluster deployment.  (Note to WSL users: You may need to either move the executables to /usr/local/bin, or modify ~/.bashrc to add them to PATH and persist the new additions across restarts.)
 
 ## Follow Cloud Provider Guide
 
-Bedrock provides templates for creating Kubernetes clusters for each supported cloud provider (currently only Azure -- but we would gratefully accept pull requests for other cloud providers).  Follow the instructions for the cloud provider you'd like to create a cluster environment for to get started:
+Bedrock provides templates for creating Kubernetes clusters for each supported cloud provider (currently only Azure -- but we would gratefully accept pull requests for other cloud providers).  Follow the instructions for the cloud provider on which you'd like to create your cluster environment to get started:
 
 - [Creating a Azure Kubernetes Service (AKS) cluster environment](./azure)
 - [Creating a Minikube cluster environment](./minikube)

--- a/cluster/environments/azure-common-infra/README.md
+++ b/cluster/environments/azure-common-infra/README.md
@@ -68,7 +68,7 @@ container_name="myContainer"
 key="tfstate-common-infra"
 ```
 
-Create a `terraform.tfvars` if it does not already exist. It should include the following variables and look something like this:
+Create a `terraform.tfvars` if it does not already exist. It should include the following variables and look something like the below. In addition to these values, environments may have additional variables. Check the `variables.tf` file for your template for specifics. 
 
 ```
 vnet_name = "myvnet"

--- a/cluster/environments/azure-multiple-clusters/README.md
+++ b/cluster/environments/azure-multiple-clusters/README.md
@@ -2,7 +2,7 @@
 
 The `azure-multiple-cluster` environment deploys three redundant clusters (similar to that deployed with the `azure-single-keyvault` environment with flux and Azure Key Vault), each behind [Azure Traffic Manager](https://azure.microsoft.com/en-us/services/traffic-manager/), which is configured with rules for routing traffic to one of the three clusters.
 
-`azure-multiple-cluster` is dependant on a deployment of [`azure-common-infra`](../azure-common-infra).
+The [`azure-common-infra`](../azure-common-infra) template must be deployed first.
 
 ## Getting Started
 

--- a/cluster/environments/azure-single-keyvault/README.md
+++ b/cluster/environments/azure-single-keyvault/README.md
@@ -1,10 +1,10 @@
 # azure-single-keyvault
 
-The `azure-single-keyvault` environment deploys a single production level AKS cluster configured with Flux and Azure Keyvault.
+The `azure-single-keyvault` environment deploys a single production level AKS cluster configured with Flux and Azure Keyvault. The [`azure-common-infra`](../azure-common-infra) template must be deployed first.
 
 ## Getting Started
 
-1. Copy this template directory to a repo of its own. Bedrock environments remotely reference the Terraform modules that they need and do not need be housed in the Bedrock repo.
+1. Copy this template directory to a repo of its own, or one shared with the azure-common-infra. Bedrock environments remotely reference the Terraform modules that they need and do not need be housed in the Bedrock repo.
 2. Follow the instructions on the [main Azure page](../../azure) in this repo to create your cluster and surrounding infrastructure.
 
 ## Deploy the Environment
@@ -23,7 +23,7 @@ container_name="myContainer"
 key="tfstate-single-keyvault"
 ```
 
-If there is not a `terraform.tfvars`, create one that looks like this:
+If there is not a `terraform.tfvars`, create one that looks like the below. In addition to these values, environments may have additional variables. Check the `variables.tf` file for your template for specifics.
 
 ```
 #--------------------------------------------------------------


### PR DESCRIPTION
Add updates regarding terraform version, package installation, and other details that have created stumbling blocks for users new to Bedrock. Many changes are outcome of customer hack with Microsoft in Sweden. Added repetition across some instruction pages for clarity and to prevent having to click back and forth quite as much.

- Reference Terraform v0.11.14, give more direct link to version
- Recommend avoiding `snap` for installation, more direct link to download pages
- Make order of operations clearer for multi-step template deployment
- Clarify expected computer OS, shell, setup