### PR TITLE
Terminate script if fab set commands fails

### DIFF
--- a/gitops/azure-devops/release.sh
+++ b/gitops/azure-devops/release.sh
@@ -24,6 +24,9 @@ else
     echo "fab set --subcomponent "$SUBCOMPONENT" "$YAML_PATH=$YAML_PATH_VALUE""
     fab set --subcomponent "$SUBCOMPONENT" "$YAML_PATH=$YAML_PATH_VALUE"
 fi
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
 
 echo "GIT STATUS"
 git status


### PR DESCRIPTION
Making the Azure DevOps release script terminate if Fabricate CLI fails. Otherwise it appears as the release succeeded in Azure DevOps.  Closes #560 