### PR TITLE
Update storage-account.tf

### DIFF
--- a/cluster/azure/backend-state/storage-account.tf
+++ b/cluster/azure/backend-state/storage-account.tf
@@ -1,7 +1,7 @@
 resource "random_id" "remotestate_account_name" {
   byte_length = 6
 
-  keepers {
+  keepers = {
     sa_account_ref = 1
   }
 }


### PR DESCRIPTION
Added an equals where one is expected by terraform.

Fixes error ````Blocks of type "keepers" are not expected here. Did you mean to define
argument "keepers"? If so, use the equals sign to assign it a value.````