### PR TITLE
bugs and feature requests default to triage state

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,9 @@
 name: Bug report
 about: Create a report to help us improve
 title: ""
-labels: bug
+labels:
+  - bug
+  - triage
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,9 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ""
-labels: enhancement
+labels:
+  - enhancement
+  - triage
 assignees: ""
 ---
 


### PR DESCRIPTION
Have added the default `triage` label to newly created bugs/feature-requests. We will filter on this label at the start of all grooming sessions so we can clean-up and make clear stories for all newly added issues; Subsequently removing the label after being cleared by team.