### PR TITLE
Reference deploy azure cluster section

### DIFF
--- a/cluster/azure/README.md
+++ b/cluster/azure/README.md
@@ -32,6 +32,7 @@ The following templates are currently available for deployment:
 - [azure-single-keyvault](../environments/azure-single-keyvault): Single cluster with Azure Keyvault integration through flex volumes template.
 - [azure-multiple-clusters](../environments/azure-multiple-clusters/): Multiple cluster deployment with Traffic Manager.
 
+### Deploying Azure Cluster
 The common steps necessary to deploy a cluster are:
 
 - [Build Fabrikate Definition for Container Deployment](../../docs/fabrikate/README.md)

--- a/cluster/environments/azure-simple/README.md
+++ b/cluster/environments/azure-simple/README.md
@@ -5,7 +5,7 @@ The `azure-simple` environment is a non-production ready template we provide to 
 ## Getting Started
 
 1. Copy this template directory to a repo of its own. Bedrock environments remotely reference the Terraform modules that they need and do not need be housed in the Bedrock repo.
-2. Follow the instructions on the [main Azure page](../../azure) in this repo to create your cluster and surrounding infrastructure.
+2. Follow the instructions on the [main Azure page](../../azure#Deploying-Azure-Cluster) in this repo to create your cluster and surrounding infrastructure.
 
 ## Resource Group Requirement
 

--- a/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/README.md
+++ b/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/README.md
@@ -9,7 +9,7 @@ The Azure Single Cluster environment requires the creation of a single resource 
 ## Getting Started
 
 1. Copy this template directory to a repo of its own. Bedrock environments remotely reference the Terraform modules that they need and do not need be housed in the Bedrock repo.
-2. Follow the instructions on the [main Azure page](../../azure) in this repo to create your cluster and surrounding infrastructure. This environment is dependant on a deployment on [azure-common-infra](../azure-common-infra), so configure and deploy azure-common-ifra prior to deploying `azure-single-keyvault-cosmos-mongo-db-simple`.
+2. Follow the instructions on the [main Azure page](../../azure#Deploying-Azure-Cluster) in this repo to create your cluster and surrounding infrastructure. This environment is dependant on a deployment on [azure-common-infra](../azure-common-infra), so configure and deploy azure-common-ifra prior to deploying `azure-single-keyvault-cosmos-mongo-db-simple`.
 
 ## Deploy the Environment
 

--- a/cluster/environments/azure-single-keyvault/README.md
+++ b/cluster/environments/azure-single-keyvault/README.md
@@ -5,7 +5,7 @@ The `azure-single-keyvault` environment deploys a single production level AKS cl
 ## Getting Started
 
 1. Copy this template directory to a repo of its own. Bedrock environments remotely reference the Terraform modules that they need and do not need be housed in the Bedrock repo.
-2. Follow the instructions on the [main Azure page](../../azure) in this repo to create your cluster and surrounding infrastructure.
+2. Follow the instructions on the [main Azure page](../../azure#Deploying-Azure-Cluster) in this repo to create your cluster and surrounding infrastructure.
 
 ## Resource Group Requirement
 


### PR DESCRIPTION
Modified markdown to reference the deploying of azure cluster section. Before this change, we are referencing the entire README.md, hence it is difficult for our readers to know (precisely) which section to read.