### PR TITLE
Plumb k8s version from environments to aks-gitops and aks modules

### DIFF
--- a/cluster/azure/aks-gitops/main.tf
+++ b/cluster/azure/aks-gitops/main.tf
@@ -1,5 +1,5 @@
 data "azurerm_resource_group" "aksgitops" {
-    name = "${var.resource_group_name}"
+  name = "${var.resource_group_name}"
 }
 
 module "aks" {
@@ -17,6 +17,7 @@ module "aks" {
   service_cidr             = "${var.service_cidr}"
   dns_ip                   = "${var.dns_ip}"
   docker_cidr              = "${var.docker_cidr}"
+  kubernetes_version       = "${var.kubernetes_version}"
   kubeconfig_filename      = "${var.kubeconfig_filename}"
   network_policy           = "${var.network_policy}"
   network_plugin           = "${var.network_plugin}"

--- a/cluster/azure/aks-gitops/variables.tf
+++ b/cluster/azure/aks-gitops/variables.tf
@@ -59,6 +59,11 @@ variable "gitops_url_branch" {
   type = "string"
 }
 
+variable "kubernetes_version" {
+  type    = "string"
+  default = ""
+}
+
 variable "resource_group_name" {
   type = "string"
 }

--- a/cluster/azure/aks-gitops/variables.tf
+++ b/cluster/azure/aks-gitops/variables.tf
@@ -60,8 +60,7 @@ variable "gitops_url_branch" {
 }
 
 variable "kubernetes_version" {
-  type    = "string"
-  default = ""
+  type = "string"
 }
 
 variable "resource_group_name" {

--- a/cluster/azure/aks/variables.tf
+++ b/cluster/azure/aks/variables.tf
@@ -30,8 +30,7 @@ variable "agent_vm_size" {
 }
 
 variable "kubernetes_version" {
-  type    = "string"
-  default = ""
+  type = "string"
 }
 
 variable "admin_user" {

--- a/cluster/azure/aks/variables.tf
+++ b/cluster/azure/aks/variables.tf
@@ -31,7 +31,7 @@ variable "agent_vm_size" {
 
 variable "kubernetes_version" {
   type    = "string"
-  default = "1.14.8"
+  default = ""
 }
 
 variable "admin_user" {

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-centralus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-centralus.tf
@@ -28,7 +28,7 @@ module "central_vnet" {
 
 # Creates aks cluster
 module "central_aks" {
-  source = "../../azure/aks"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks"
 
   resource_group_name      = "${local.central_rg_name}"
   cluster_name             = "${var.cluster_name}-central"

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-centralus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-centralus.tf
@@ -28,7 +28,7 @@ module "central_vnet" {
 
 # Creates aks cluster
 module "central_aks" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks"
+  source = "../../azure/aks"
 
   resource_group_name      = "${local.central_rg_name}"
   cluster_name             = "${var.cluster_name}-central"

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-centralus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-centralus.tf
@@ -42,6 +42,7 @@ module "central_aks" {
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"
   kubeconfig_filename      = "${local.central_kubeconfig_filename}"
+  kubernetes_version       = "${var.kubernetes_version}"
   oms_agent_enabled        = "${var.oms_agent_enabled}"
 }
 

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-eastus.tf
@@ -42,6 +42,7 @@ module "east_aks" {
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"
   kubeconfig_filename      = "${local.east_kubeconfig_filename}"
+  kubernetes_version       = "${var.kubernetes_version}"
   oms_agent_enabled        = "${var.oms_agent_enabled}"
 }
 

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-eastus.tf
@@ -28,7 +28,7 @@ module "east_vnet" {
 
 # Creates aks cluster
 module "east_aks" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks"
+  source = "../../azure/aks"
 
   resource_group_name      = "${local.east_rg_name}"
   cluster_name             = "${var.cluster_name}-east"

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-eastus.tf
@@ -28,7 +28,7 @@ module "east_vnet" {
 
 # Creates aks cluster
 module "east_aks" {
-  source = "../../azure/aks"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks"
 
   resource_group_name      = "${local.east_rg_name}"
   cluster_name             = "${var.cluster_name}-east"

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-variables.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-variables.tf
@@ -11,6 +11,11 @@ variable "dns_prefix" {
   type = "string"
 }
 
+variable "kubernetes_version" {
+  type    = "string"
+  default = "1.15.7"
+}
+
 variable "ssh_public_key" {
   type = "string"
 }

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-westus.tf
@@ -28,7 +28,7 @@ module "west_vnet" {
 
 # Creates aks cluster
 module "west_aks" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks"
+  source = "../../azure/aks"
 
   resource_group_name      = "${local.west_rg_name}"
   cluster_name             = "${var.cluster_name}-west"

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-westus.tf
@@ -38,6 +38,7 @@ module "west_aks" {
   service_cidr             = "${var.west_service_cidr}"
   dns_ip                   = "${var.west_dns_ip}"
   docker_cidr              = "${var.west_docker_cidr}"
+  kubernetes_version       = "${var.kubernetes_version}"
   ssh_public_key           = "${var.ssh_public_key}"
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-westus.tf
@@ -28,7 +28,7 @@ module "west_vnet" {
 
 # Creates aks cluster
 module "west_aks" {
-  source = "../../azure/aks"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks"
 
   resource_group_name      = "${local.west_rg_name}"
   cluster_name             = "${var.cluster_name}-west"

--- a/cluster/environments/azure-multiple-clusters/aks-centralus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-centralus.tf
@@ -28,7 +28,7 @@ module "central_vnet" {
 
 # Creates central aks cluster, flux, kubediff
 module "central_aks_gitops" {
-  source = "../../azure/aks-gitops"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-multiple-clusters/aks-centralus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-centralus.tf
@@ -28,7 +28,7 @@ module "central_vnet" {
 
 # Creates central aks cluster, flux, kubediff
 module "central_aks_gitops" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
+  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-multiple-clusters/aks-centralus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-centralus.tf
@@ -28,7 +28,7 @@ module "central_vnet" {
 
 # Creates central aks cluster, flux, kubediff
 module "central_aks_gitops" {
-  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-multiple-clusters/aks-centralus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-centralus.tf
@@ -1,5 +1,5 @@
 data "azurerm_resource_group" "centralrg" {
-  name     = "${var.central_resource_group_name}"
+  name = "${var.central_resource_group_name}"
 }
 
 # local variable with cluster and location specific
@@ -16,10 +16,10 @@ locals {
 module "central_vnet" {
   source = "github.com/microsoft/bedrock?ref=master//cluster/azure/vnet"
 
-  resource_group_name     = "${local.central_rg_name }"
-  subnet_names            = ["${var.cluster_name}_aks_subnet"]
-  address_space           = "${var.central_address_space}"
-  subnet_prefixes         = "${var.central_subnet_prefixes}"
+  resource_group_name = "${local.central_rg_name}"
+  subnet_names        = ["${var.cluster_name}_aks_subnet"]
+  address_space       = "${var.central_address_space}"
+  subnet_prefixes     = "${var.central_subnet_prefixes}"
 
   tags = {
     environment = "azure_multiple_clusters"
@@ -43,6 +43,7 @@ module "central_aks_gitops" {
   gitops_url_branch        = "${var.gitops_central_url_branch}"
   gitops_poll_interval     = "${var.gitops_poll_interval}"
   gitops_label             = "${var.gitops_label}"
+  kubernetes_version       = "${var.kubernetes_version}"
   resource_group_name      = "${local.central_rg_name}"
   service_cidr             = "${var.central_service_cidr}"
   service_principal_id     = "${var.service_principal_id}"

--- a/cluster/environments/azure-multiple-clusters/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus.tf
@@ -28,7 +28,7 @@ module "east_vnet" {
 
 # Creates east aks cluster, flux, kubediff
 module "east_aks_gitops" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
+  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-multiple-clusters/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus.tf
@@ -28,7 +28,7 @@ module "east_vnet" {
 
 # Creates east aks cluster, flux, kubediff
 module "east_aks_gitops" {
-  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-multiple-clusters/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus.tf
@@ -1,5 +1,5 @@
 data "azurerm_resource_group" "eastrg" {
-  name     = "${var.east_resource_group_name}"
+  name = "${var.east_resource_group_name}"
 }
 
 # local variable with cluster and location specific
@@ -16,10 +16,10 @@ locals {
 module "east_vnet" {
   source = "github.com/microsoft/bedrock?ref=master//cluster/azure/vnet"
 
-  resource_group_name     = "${local.east_rg_name }"
-  subnet_names            = ["${var.cluster_name}_aks_subnet"]
-  address_space           = "${var.east_address_space}"
-  subnet_prefixes         = "${var.east_subnet_prefixes}"
+  resource_group_name = "${local.east_rg_name}"
+  subnet_names        = ["${var.cluster_name}_aks_subnet"]
+  address_space       = "${var.east_address_space}"
+  subnet_prefixes     = "${var.east_subnet_prefixes}"
 
   tags = {
     environment = "azure_multiple_clusters"
@@ -43,6 +43,7 @@ module "east_aks_gitops" {
   gitops_url_branch        = "${var.gitops_east_url_branch}"
   gitops_poll_interval     = "${var.gitops_poll_interval}"
   gitops_label             = "${var.gitops_label}"
+  kubernetes_version       = "${var.kubernetes_version}"
   resource_group_name      = "${local.east_rg_name}"
   service_cidr             = "${var.east_service_cidr}"
   service_principal_id     = "${var.service_principal_id}"

--- a/cluster/environments/azure-multiple-clusters/aks-eastus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-eastus.tf
@@ -28,7 +28,7 @@ module "east_vnet" {
 
 # Creates east aks cluster, flux, kubediff
 module "east_aks_gitops" {
-  source = "../../azure/aks-gitops"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-multiple-clusters/aks-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-variables.tf
@@ -15,6 +15,11 @@ variable "dns_prefix" {
   type = "string"
 }
 
+variable "kubernetes_version" {
+  type    = "string"
+  default = "1.15.7"
+}
+
 variable "ssh_public_key" {
   type = "string"
 }

--- a/cluster/environments/azure-multiple-clusters/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus.tf
@@ -28,7 +28,7 @@ module "west_vnet" {
 
 # Creates west aks cluster, flux, kubediff
 module "west_aks_gitops" {
-  source = "../../azure/aks-gitops"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-multiple-clusters/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus.tf
@@ -28,7 +28,7 @@ module "west_vnet" {
 
 # Creates west aks cluster, flux, kubediff
 module "west_aks_gitops" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
+  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-multiple-clusters/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus.tf
@@ -1,5 +1,5 @@
 data "azurerm_resource_group" "westrg" {
-  name     = "${var.west_resource_group_name}"
+  name = "${var.west_resource_group_name}"
 }
 
 # local variable with cluster and location specific
@@ -16,10 +16,10 @@ locals {
 module "west_vnet" {
   source = "github.com/microsoft/bedrock?ref=master//cluster/azure/vnet"
 
-  resource_group_name     = "${local.west_rg_name}"
-  subnet_names            = ["${var.cluster_name}_aks_subnet"]
-  address_space           = "${var.west_address_space}"
-  subnet_prefixes         = "${var.west_subnet_prefixes}"
+  resource_group_name = "${local.west_rg_name}"
+  subnet_names        = ["${var.cluster_name}_aks_subnet"]
+  address_space       = "${var.west_address_space}"
+  subnet_prefixes     = "${var.west_subnet_prefixes}"
 
   tags = {
     environment = "azure_multiple_clusters"
@@ -43,6 +43,7 @@ module "west_aks_gitops" {
   gitops_url_branch        = "${var.gitops_west_url_branch}"
   gitops_poll_interval     = "${var.gitops_poll_interval}"
   gitops_label             = "${var.gitops_label}"
+  kubernetes_version       = "${var.kubernetes_version}"
   resource_group_name      = "${local.west_rg_name}"
   service_cidr             = "${var.west_service_cidr}"
   service_principal_id     = "${var.service_principal_id}"

--- a/cluster/environments/azure-multiple-clusters/aks-westus.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-westus.tf
@@ -28,7 +28,7 @@ module "west_vnet" {
 
 # Creates west aks cluster, flux, kubediff
 module "west_aks_gitops" {
-  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -21,7 +21,7 @@ module "vnet" {
 }
 
 module "aks-gitops" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
+  source = "../cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -36,6 +36,7 @@ module "aks-gitops" {
   gitops_poll_interval     = "${var.gitops_poll_interval}"
   gitops_label             = "${var.gitops_label}"
   gitops_url_branch        = "${var.gitops_url_branch}"
+  kubernetes_version       = "${var.kubernetes_version}"
   ssh_public_key           = "${var.ssh_public_key}"
   resource_group_name      = "${data.azurerm_resource_group.cluster_rg.name}"
   service_principal_id     = "${var.service_principal_id}"

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -21,7 +21,7 @@ module "vnet" {
 }
 
 module "aks-gitops" {
-  source = "../../azure/aks-gitops"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -7,7 +7,7 @@ data "azurerm_resource_group" "cluster_rg" {
 }
 
 module "vnet" {
-  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/vnet"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/vnet"
 
   vnet_name           = "${var.vnet_name}"
   address_space       = "${var.address_space}"

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -21,7 +21,7 @@ module "vnet" {
 }
 
 module "aks-gitops" {
-  source = "../cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-simple/main.tf
+++ b/cluster/environments/azure-simple/main.tf
@@ -7,7 +7,7 @@ data "azurerm_resource_group" "cluster_rg" {
 }
 
 module "vnet" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/vnet"
+  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/vnet"
 
   vnet_name           = "${var.vnet_name}"
   address_space       = "${var.address_space}"

--- a/cluster/environments/azure-simple/variables.tf
+++ b/cluster/environments/azure-simple/variables.tf
@@ -50,6 +50,11 @@ variable "gitops_url_branch" {
   default = "master"
 }
 
+variable "kubernetes_version" {
+  type    = "string"
+  default = "1.15.7"
+}
+
 variable "resource_group_name" {
   type = "string"
 }

--- a/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/main.tf
+++ b/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/main.tf
@@ -19,7 +19,7 @@ data "azurerm_subnet" "vnet" {
 }
 
 module "aks-gitops" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
+  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/main.tf
+++ b/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/main.tf
@@ -33,6 +33,7 @@ module "aks-gitops" {
   gitops_poll_interval     = "${var.gitops_poll_interval}"
   gitops_label             = "${var.gitops_label}"
   gitops_url_branch        = "${var.gitops_url_branch}"
+  kubernetes_version       = "${var.kubernetes_version}"
   resource_group_name      = "${data.azurerm_resource_group.cluster_rg.name}"
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"

--- a/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/main.tf
+++ b/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/main.tf
@@ -19,7 +19,7 @@ data "azurerm_subnet" "vnet" {
 }
 
 module "aks-gitops" {
-  source = "../../azure/aks-gitops"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/main.tf
+++ b/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/main.tf
@@ -19,7 +19,7 @@ data "azurerm_subnet" "vnet" {
 }
 
 module "aks-gitops" {
-  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/variables.tf
+++ b/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/variables.tf
@@ -70,6 +70,11 @@ variable "keyvault_resource_group" {
   type = "string"
 }
 
+variable "kubernetes_version" {
+  type    = "string"
+  default = "1.15.7"
+}
+
 variable "resource_group_name" {
   type = "string"
 }

--- a/cluster/environments/azure-single-keyvault/main.tf
+++ b/cluster/environments/azure-single-keyvault/main.tf
@@ -34,6 +34,7 @@ module "aks-gitops" {
   gitops_poll_interval     = "${var.gitops_poll_interval}"
   gitops_label             = "${var.gitops_label}"
   gitops_url_branch        = "${var.gitops_url_branch}"
+  kubernetes_version       = "${var.kubernetes_version}"
   resource_group_name      = "${data.azurerm_resource_group.cluster_rg.name}"
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"

--- a/cluster/environments/azure-single-keyvault/main.tf
+++ b/cluster/environments/azure-single-keyvault/main.tf
@@ -19,7 +19,7 @@ data "azurerm_subnet" "vnet" {
 }
 
 module "aks-gitops" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
+  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-single-keyvault/main.tf
+++ b/cluster/environments/azure-single-keyvault/main.tf
@@ -43,26 +43,3 @@ module "aks-gitops" {
   network_policy           = "${var.network_policy}"
   oms_agent_enabled        = "${var.oms_agent_enabled}"
 }
-
-# Create Azure Key Vault role for SP
-module "keyvault_flexvolume_role" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/keyvault_flexvol_role"
-
-  resource_group_name  = "${data.azurerm_resource_group.keyvault.name}"
-  service_principal_id = "${var.service_principal_id}"
-  subscription_id      = "${data.azurerm_client_config.current.subscription_id}"
-  keyvault_name        = "${var.keyvault_name}"
-}
-
-# Deploy central keyvault flexvolume
-module "flex_volume" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/keyvault_flexvol"
-
-  resource_group_name      = "${data.azurerm_resource_group.keyvault.name}"
-  service_principal_id     = "${var.service_principal_id}"
-  service_principal_secret = "${var.service_principal_secret}"
-  tenant_id                = "${data.azurerm_client_config.current.tenant_id}"
-  keyvault_name            = "${var.keyvault_name}"
-
-  kubeconfig_complete = "${module.aks-gitops.kubeconfig_done}"
-}

--- a/cluster/environments/azure-single-keyvault/main.tf
+++ b/cluster/environments/azure-single-keyvault/main.tf
@@ -19,7 +19,7 @@ data "azurerm_subnet" "vnet" {
 }
 
 module "aks-gitops" {
-  source = "../../azure/aks-gitops"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-single-keyvault/main.tf
+++ b/cluster/environments/azure-single-keyvault/main.tf
@@ -19,7 +19,7 @@ data "azurerm_subnet" "vnet" {
 }
 
 module "aks-gitops" {
-  source = "github.com/timfpark/bedrock?ref=plumb_k8s_version//cluster/azure/aks-gitops"
+  source = "../../azure/aks-gitops"
 
   acr_enabled              = "${var.acr_enabled}"
   agent_vm_count           = "${var.agent_vm_count}"

--- a/cluster/environments/azure-single-keyvault/variables.tf
+++ b/cluster/environments/azure-single-keyvault/variables.tf
@@ -70,6 +70,11 @@ variable "keyvault_resource_group" {
   type = "string"
 }
 
+variable "kubernetes_version" {
+  type    = "string"
+  default = ""
+}
+
 variable "resource_group_name" {
   type = "string"
 }

--- a/cluster/environments/azure-single-keyvault/variables.tf
+++ b/cluster/environments/azure-single-keyvault/variables.tf
@@ -72,7 +72,7 @@ variable "keyvault_resource_group" {
 
 variable "kubernetes_version" {
   type    = "string"
-  default = ""
+  default = "1.15.7"
 }
 
 variable "resource_group_name" {

--- a/cluster/environments/azure-velero-restore/main.tf
+++ b/cluster/environments/azure-velero-restore/main.tf
@@ -24,7 +24,7 @@ resource "null_resource" "cloud_credentials" {
 }
 
 module "aks" {
-  source = "../../azure/aks"
+  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks"
 
   agent_vm_count           = "${var.agent_vm_count}"
   agent_vm_size            = "${var.agent_vm_size}"

--- a/cluster/environments/azure-velero-restore/main.tf
+++ b/cluster/environments/azure-velero-restore/main.tf
@@ -24,7 +24,7 @@ resource "null_resource" "cloud_credentials" {
 }
 
 module "aks" {
-  source = "github.com/microsoft/bedrock?ref=master//cluster/azure/aks"
+  source = "../../azure/aks"
 
   agent_vm_count           = "${var.agent_vm_count}"
   agent_vm_size            = "${var.agent_vm_size}"

--- a/cluster/environments/azure-velero-restore/main.tf
+++ b/cluster/environments/azure-velero-restore/main.tf
@@ -14,7 +14,7 @@ data "azurerm_resource_group" "cluster_rg" {
 }
 
 data "azurerm_resource_group" "keyvault" {
-  name     = "${var.keyvault_resource_group}"
+  name = "${var.keyvault_resource_group}"
 }
 
 resource "null_resource" "cloud_credentials" {
@@ -30,6 +30,7 @@ module "aks" {
   agent_vm_size            = "${var.agent_vm_size}"
   cluster_name             = "${var.cluster_name}"
   dns_prefix               = "${var.dns_prefix}"
+  kubernetes_version       = "${var.kubernetes_version}"
   resource_group_name      = "${data.azurerm_resource_group.cluster_rg.name}"
   service_principal_id     = "${var.service_principal_id}"
   service_principal_secret = "${var.service_principal_secret}"

--- a/cluster/environments/azure-velero-restore/variables.tf
+++ b/cluster/environments/azure-velero-restore/variables.tf
@@ -76,6 +76,11 @@ variable "keyvault_resource_group" {
   type = "string"
 }
 
+variable "kubernetes_version" {
+  type    = "string"
+  default = "1.15.7"
+}
+
 variable "resource_group_name" {
   type = "string"
 }

--- a/test/bedrock_Azure_common_kv_test.go
+++ b/test/bedrock_Azure_common_kv_test.go
@@ -2,16 +2,15 @@ package test
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/otiai10/copy"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
-
-	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/otiai10/copy"
 )
 
 func TestIT_Bedrock_AzureCommon_KV_Test(t *testing.T) {
@@ -24,6 +23,7 @@ func TestIT_Bedrock_AzureCommon_KV_Test(t *testing.T) {
 	kvName := k8sName + "-kv"
 	kvRG := kvName + "-rg"
 	k8sVersion := "1.15.7"
+
 	location := os.Getenv("DATACENTER_LOCATION")
 	clientid := os.Getenv("ARM_CLIENT_ID")
 	clientsecret := os.Getenv("ARM_CLIENT_SECRET")
@@ -42,20 +42,20 @@ func TestIT_Bedrock_AzureCommon_KV_Test(t *testing.T) {
 	copy.Copy("../cluster/environments/azure-common-infra", azureCommonInfraFolder)
 
 	//Create the resource group
-	cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
-	err0 := cmd0.Run()
-	if err0 != nil {
-		fmt.Println("unable to login to azure cli")
-		log.Fatal(err0)
-		os.Exit(-1)
-	}
-	cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
-	err1 := cmd1.Run()
-	if err1 != nil {
-		fmt.Println("failed to create resource group")
-		log.Fatal(err1)
-		os.Exit(-1)
-	}
+        cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
+        err0 := cmd0.Run()
+        if err0 != nil {
+                fmt.Println("unable to login to azure cli")
+                log.Fatal(err0)
+                os.Exit(-1)
+        }
+        cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
+        err1 := cmd1.Run()
+        if err1 != nil {
+                fmt.Println("failed to create resource group")
+                log.Fatal(err1)
+                os.Exit(-1)
+        }
 
 	//Specify the test case folder and "-var" option mapping for the backend
 	common_backend_tfOptions := &terraform.Options{

--- a/test/bedrock_Azure_common_kv_test.go
+++ b/test/bedrock_Azure_common_kv_test.go
@@ -2,15 +2,16 @@ package test
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/otiai10/copy"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/otiai10/copy"
 )
 
 func TestIT_Bedrock_AzureCommon_KV_Test(t *testing.T) {
@@ -22,6 +23,7 @@ func TestIT_Bedrock_AzureCommon_KV_Test(t *testing.T) {
 	addressSpace := "10.39.0.0/16"
 	kvName := k8sName + "-kv"
 	kvRG := kvName + "-rg"
+	k8sVersion := "1.15.7"
 	location := os.Getenv("DATACENTER_LOCATION")
 	clientid := os.Getenv("ARM_CLIENT_ID")
 	clientsecret := os.Getenv("ARM_CLIENT_SECRET")
@@ -40,20 +42,20 @@ func TestIT_Bedrock_AzureCommon_KV_Test(t *testing.T) {
 	copy.Copy("../cluster/environments/azure-common-infra", azureCommonInfraFolder)
 
 	//Create the resource group
-        cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
-        err0 := cmd0.Run()
-        if err0 != nil {
-                fmt.Println("unable to login to azure cli")
-                log.Fatal(err0)
-                os.Exit(-1)
-        }
-        cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
-        err1 := cmd1.Run()
-        if err1 != nil {
-                fmt.Println("failed to create resource group")
-                log.Fatal(err1)
-                os.Exit(-1)
-        }
+	cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
+	err0 := cmd0.Run()
+	if err0 != nil {
+		fmt.Println("unable to login to azure cli")
+		log.Fatal(err0)
+		os.Exit(-1)
+	}
+	cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
+	err1 := cmd1.Run()
+	if err1 != nil {
+		fmt.Println("failed to create resource group")
+		log.Fatal(err1)
+		os.Exit(-1)
+	}
 
 	//Specify the test case folder and "-var" option mapping for the backend
 	common_backend_tfOptions := &terraform.Options{
@@ -129,6 +131,7 @@ func TestIT_Bedrock_AzureCommon_KV_Test(t *testing.T) {
 			"gitops_ssh_key":           sshkey,
 			"keyvault_name":            kvName,
 			"keyvault_resource_group":  kvRG,
+			"kubernetes_version":       k8sVersion,
 			"resource_group_name":      k8sRG,
 			"ssh_public_key":           publickey,
 			"service_principal_id":     clientid,

--- a/test/bedrock_Azure_mc_test.go
+++ b/test/bedrock_Azure_mc_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -53,6 +52,7 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 
 	kvName := k8sName + "-kv"
 	kvRG := kvName + "-rg"
+	k8sVersion := "1.15.7"
 
 	//Generate common-infra backend for tf.state files to be persisted in azure storage account
 	backendName := os.Getenv("ARM_BACKEND_STORAGE_NAME")
@@ -64,21 +64,21 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 	azureCommonInfraFolder := "../cluster/test-temp-envs/azure-common-infra-" + k8sName
 	copy.Copy("../cluster/environments/azure-common-infra", azureCommonInfraFolder)
 
-        //Create the common resource group
-        cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
-        err0 := cmd0.Run()
-        if err0 != nil {
-                fmt.Println("unable to login to azure cli")
-                log.Fatal(err0)
-                os.Exit(-1)
-        }
-        cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
-        err1 := cmd1.Run()
-        if err1 != nil {
-                fmt.Println("failed to create common resource group")
-                log.Fatal(err1)
-                os.Exit(-1)
-        }
+	//Create the common resource group
+	cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
+	err0 := cmd0.Run()
+	if err0 != nil {
+		fmt.Println("unable to login to azure cli")
+		log.Fatal(err0)
+		os.Exit(-1)
+	}
+	cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
+	err1 := cmd1.Run()
+	if err1 != nil {
+		fmt.Println("failed to create common resource group")
+		log.Fatal(err1)
+		os.Exit(-1)
+	}
 
 	//Specify the test case folder and "-var" option mapping for the backend
 	common_backend_tfOptions := &terraform.Options{
@@ -96,13 +96,13 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 		TerraformDir: azureCommonInfraFolder,
 		Upgrade:      true,
 		Vars: map[string]interface{}{
-			"address_space":                  addressSpace,
-			"keyvault_name":                  kvName,
-			"global_resource_group_name":     kvRG,
-			"service_principal_id":           clientid,
-			"subnet_name":                    subnetName,
-			"subnet_prefix":                  addressSpace,
-			"vnet_name":                      vnetName,
+			"address_space":              addressSpace,
+			"keyvault_name":              kvName,
+			"global_resource_group_name": kvRG,
+			"service_principal_id":       clientid,
+			"subnet_name":                subnetName,
+			"subnet_prefix":              addressSpace,
+			"vnet_name":                  vnetName,
 		},
 	}
 
@@ -126,38 +126,38 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 	cluster_location2 := "eastus2"
 	cluster_location3 := "centralus"
 
-        //Create the east resource group
-        cmd2 := exec.Command("az", "group", "create", "-n", k8s_eastRG, "-l", cluster_location2)
-        err2 := cmd2.Run()
-        if err2 != nil {
-                fmt.Println("failed to create east resource group")
-                log.Fatal(err2)
-                os.Exit(-1)
-        }
-        //Create the west resource group
-        cmd3 := exec.Command("az", "group", "create", "-n", k8s_westRG, "-l", cluster_location1)
-        err3 := cmd3.Run()
-        if err3 != nil {
-                fmt.Println("failed to create west resource group")
-                log.Fatal(err3)
-                os.Exit(-1)
-        }
-        //Create the central resource group
-        cmd4 := exec.Command("az", "group", "create", "-n", k8s_centralRG, "-l", cluster_location3)
-        err4 := cmd4.Run()
-        if err4 != nil {
-                fmt.Println("failed to create central resource group")
-                log.Fatal(err4)
-                os.Exit(-1)
-        }
-        //Create the global resource group
-        cmd5 := exec.Command("az", "group", "create", "-n", k8s_globalRG, "-l", location)
-        err5 := cmd5.Run()
-        if err5 != nil {
-                fmt.Println("failed to create global resource group")
-                log.Fatal(err5)
-                os.Exit(-1)
-        }
+	//Create the east resource group
+	cmd2 := exec.Command("az", "group", "create", "-n", k8s_eastRG, "-l", cluster_location2)
+	err2 := cmd2.Run()
+	if err2 != nil {
+		fmt.Println("failed to create east resource group")
+		log.Fatal(err2)
+		os.Exit(-1)
+	}
+	//Create the west resource group
+	cmd3 := exec.Command("az", "group", "create", "-n", k8s_westRG, "-l", cluster_location1)
+	err3 := cmd3.Run()
+	if err3 != nil {
+		fmt.Println("failed to create west resource group")
+		log.Fatal(err3)
+		os.Exit(-1)
+	}
+	//Create the central resource group
+	cmd4 := exec.Command("az", "group", "create", "-n", k8s_centralRG, "-l", cluster_location3)
+	err4 := cmd4.Run()
+	if err4 != nil {
+		fmt.Println("failed to create central resource group")
+		log.Fatal(err4)
+		os.Exit(-1)
+	}
+	//Create the global resource group
+	cmd5 := exec.Command("az", "group", "create", "-n", k8s_globalRG, "-l", location)
+	err5 := cmd5.Run()
+	if err5 != nil {
+		fmt.Println("failed to create global resource group")
+		log.Fatal(err5)
+		os.Exit(-1)
+	}
 
 	publickey := os.Getenv("public_key")
 	sshkey := os.Getenv("ssh_key")
@@ -186,19 +186,20 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 			"gitops_label":             "flux-sync",
 			"keyvault_name":            kvName,
 			"keyvault_resource_group":  kvRG,
+			"kubernetes_version":       k8sVersion,
 
-			"traffic_manager_profile_name":            tmName,
-			"traffic_manager_dns_name":                tm_dnsprefix,
-			"traffic_manager_resource_group_name":     k8s_globalRG,
+			"traffic_manager_profile_name":        tmName,
+			"traffic_manager_dns_name":            tm_dnsprefix,
+			"traffic_manager_resource_group_name": k8s_globalRG,
 
-			"west_resource_group_name":     k8s_westRG,
-			"gitops_west_path":             "",
+			"west_resource_group_name": k8s_westRG,
+			"gitops_west_path":         "",
 
-			"east_resource_group_name":     k8s_eastRG,
-			"gitops_east_path":             "",
+			"east_resource_group_name": k8s_eastRG,
+			"gitops_east_path":         "",
 
-			"central_resource_group_name":     k8s_centralRG,
-			"gitops_central_path":             "",
+			"central_resource_group_name": k8s_centralRG,
+			"gitops_central_path":         "",
 		},
 	}
 

--- a/test/bedrock_Azure_mc_test.go
+++ b/test/bedrock_Azure_mc_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -40,6 +41,7 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 	// Generate a common infra resources for integration use with azure multicluster environment
 	uniqueID := strings.ToLower(random.UniqueId())
 	k8sName := fmt.Sprintf("gtestk8s-%s", uniqueID)
+        k8sVersion := "1.15.7"
 
 	location := os.Getenv("DATACENTER_LOCATION")
 	clientid := os.Getenv("ARM_CLIENT_ID")
@@ -52,7 +54,6 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 
 	kvName := k8sName + "-kv"
 	kvRG := kvName + "-rg"
-	k8sVersion := "1.15.7"
 
 	//Generate common-infra backend for tf.state files to be persisted in azure storage account
 	backendName := os.Getenv("ARM_BACKEND_STORAGE_NAME")
@@ -64,21 +65,21 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 	azureCommonInfraFolder := "../cluster/test-temp-envs/azure-common-infra-" + k8sName
 	copy.Copy("../cluster/environments/azure-common-infra", azureCommonInfraFolder)
 
-	//Create the common resource group
-	cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
-	err0 := cmd0.Run()
-	if err0 != nil {
-		fmt.Println("unable to login to azure cli")
-		log.Fatal(err0)
-		os.Exit(-1)
-	}
-	cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
-	err1 := cmd1.Run()
-	if err1 != nil {
-		fmt.Println("failed to create common resource group")
-		log.Fatal(err1)
-		os.Exit(-1)
-	}
+        //Create the common resource group
+        cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
+        err0 := cmd0.Run()
+        if err0 != nil {
+                fmt.Println("unable to login to azure cli")
+                log.Fatal(err0)
+                os.Exit(-1)
+        }
+        cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
+        err1 := cmd1.Run()
+        if err1 != nil {
+                fmt.Println("failed to create common resource group")
+                log.Fatal(err1)
+                os.Exit(-1)
+        }
 
 	//Specify the test case folder and "-var" option mapping for the backend
 	common_backend_tfOptions := &terraform.Options{
@@ -96,13 +97,13 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 		TerraformDir: azureCommonInfraFolder,
 		Upgrade:      true,
 		Vars: map[string]interface{}{
-			"address_space":              addressSpace,
-			"keyvault_name":              kvName,
-			"global_resource_group_name": kvRG,
-			"service_principal_id":       clientid,
-			"subnet_name":                subnetName,
-			"subnet_prefix":              addressSpace,
-			"vnet_name":                  vnetName,
+			"address_space":                  addressSpace,
+			"keyvault_name":                  kvName,
+			"global_resource_group_name":     kvRG,
+			"service_principal_id":           clientid,
+			"subnet_name":                    subnetName,
+			"subnet_prefix":                  addressSpace,
+			"vnet_name":                      vnetName,
 		},
 	}
 
@@ -126,38 +127,38 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 	cluster_location2 := "eastus2"
 	cluster_location3 := "centralus"
 
-	//Create the east resource group
-	cmd2 := exec.Command("az", "group", "create", "-n", k8s_eastRG, "-l", cluster_location2)
-	err2 := cmd2.Run()
-	if err2 != nil {
-		fmt.Println("failed to create east resource group")
-		log.Fatal(err2)
-		os.Exit(-1)
-	}
-	//Create the west resource group
-	cmd3 := exec.Command("az", "group", "create", "-n", k8s_westRG, "-l", cluster_location1)
-	err3 := cmd3.Run()
-	if err3 != nil {
-		fmt.Println("failed to create west resource group")
-		log.Fatal(err3)
-		os.Exit(-1)
-	}
-	//Create the central resource group
-	cmd4 := exec.Command("az", "group", "create", "-n", k8s_centralRG, "-l", cluster_location3)
-	err4 := cmd4.Run()
-	if err4 != nil {
-		fmt.Println("failed to create central resource group")
-		log.Fatal(err4)
-		os.Exit(-1)
-	}
-	//Create the global resource group
-	cmd5 := exec.Command("az", "group", "create", "-n", k8s_globalRG, "-l", location)
-	err5 := cmd5.Run()
-	if err5 != nil {
-		fmt.Println("failed to create global resource group")
-		log.Fatal(err5)
-		os.Exit(-1)
-	}
+        //Create the east resource group
+        cmd2 := exec.Command("az", "group", "create", "-n", k8s_eastRG, "-l", cluster_location2)
+        err2 := cmd2.Run()
+        if err2 != nil {
+                fmt.Println("failed to create east resource group")
+                log.Fatal(err2)
+                os.Exit(-1)
+        }
+        //Create the west resource group
+        cmd3 := exec.Command("az", "group", "create", "-n", k8s_westRG, "-l", cluster_location1)
+        err3 := cmd3.Run()
+        if err3 != nil {
+                fmt.Println("failed to create west resource group")
+                log.Fatal(err3)
+                os.Exit(-1)
+        }
+        //Create the central resource group
+        cmd4 := exec.Command("az", "group", "create", "-n", k8s_centralRG, "-l", cluster_location3)
+        err4 := cmd4.Run()
+        if err4 != nil {
+                fmt.Println("failed to create central resource group")
+                log.Fatal(err4)
+                os.Exit(-1)
+        }
+        //Create the global resource group
+        cmd5 := exec.Command("az", "group", "create", "-n", k8s_globalRG, "-l", location)
+        err5 := cmd5.Run()
+        if err5 != nil {
+                fmt.Println("failed to create global resource group")
+                log.Fatal(err5)
+                os.Exit(-1)
+        }
 
 	publickey := os.Getenv("public_key")
 	sshkey := os.Getenv("ssh_key")
@@ -188,18 +189,18 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 			"keyvault_resource_group":  kvRG,
 			"kubernetes_version":       k8sVersion,
 
-			"traffic_manager_profile_name":        tmName,
-			"traffic_manager_dns_name":            tm_dnsprefix,
-			"traffic_manager_resource_group_name": k8s_globalRG,
+			"traffic_manager_profile_name":            tmName,
+			"traffic_manager_dns_name":                tm_dnsprefix,
+			"traffic_manager_resource_group_name":     k8s_globalRG,
 
-			"west_resource_group_name": k8s_westRG,
-			"gitops_west_path":         "",
+			"west_resource_group_name":     k8s_westRG,
+			"gitops_west_path":             "",
 
-			"east_resource_group_name": k8s_eastRG,
-			"gitops_east_path":         "",
+			"east_resource_group_name":     k8s_eastRG,
+			"gitops_east_path":             "",
 
-			"central_resource_group_name": k8s_centralRG,
-			"gitops_central_path":         "",
+			"central_resource_group_name":     k8s_centralRG,
+			"gitops_central_path":             "",
 		},
 	}
 

--- a/test/bedrock_Azure_simple_test.go
+++ b/test/bedrock_Azure_simple_test.go
@@ -28,6 +28,7 @@ func TestIT_Bedrock_AzureSimple_Test(t *testing.T) {
 	tenantId := os.Getenv("ARM_TENANT_ID")
 	dnsprefix := k8sName + "-dns"
 	k8sRG := k8sName + "-rg"
+	k8sVersion := "1.15.4"
 	location := os.Getenv("DATACENTER_LOCATION")
 	publickey := os.Getenv("public_key")
 	sshkey := os.Getenv("ssh_key")
@@ -63,6 +64,7 @@ func TestIT_Bedrock_AzureSimple_Test(t *testing.T) {
 			"dns_prefix":               dnsprefix,
 			"gitops_ssh_url":           "git@github.com:timfpark/fabrikate-cloud-native-manifests.git",
 			"gitops_ssh_key":           sshkey,
+			"kubernetes_version":       k8sVersion,
 			"resource_group_name":      k8sRG,
 			"service_principal_id":     clientid,
 			"service_principal_secret": clientsecret,

--- a/test/bedrock_Azure_simple_test.go
+++ b/test/bedrock_Azure_simple_test.go
@@ -64,7 +64,7 @@ func TestIT_Bedrock_AzureSimple_Test(t *testing.T) {
 			"dns_prefix":               dnsprefix,
 			"gitops_ssh_url":           "git@github.com:timfpark/fabrikate-cloud-native-manifests.git",
 			"gitops_ssh_key":           sshkey,
-			"kubernetes_version":       k8sVersion,
+                        "kubernetes_version":       k8sVersion,
 			"resource_group_name":      k8sRG,
 			"service_principal_id":     clientid,
 			"service_principal_secret": clientsecret,

--- a/test/bedrock_Azure_simple_test.go
+++ b/test/bedrock_Azure_simple_test.go
@@ -28,7 +28,7 @@ func TestIT_Bedrock_AzureSimple_Test(t *testing.T) {
 	tenantId := os.Getenv("ARM_TENANT_ID")
 	dnsprefix := k8sName + "-dns"
 	k8sRG := k8sName + "-rg"
-	k8sVersion := "1.15.4"
+	k8sVersion := "1.15.7"
 	location := os.Getenv("DATACENTER_LOCATION")
 	publickey := os.Getenv("public_key")
 	sshkey := os.Getenv("ssh_key")

--- a/test/bedrock_Azure_single_cosmos_mongo_test.go
+++ b/test/bedrock_Azure_single_cosmos_mongo_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -23,10 +24,11 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	addressSpace := "10.39.0.0/16"
 	kvName := k8sName + "-kv"
 	kvRG := kvName + "-rg"
+	k8sVersion := "1.15.7"
 	location := os.Getenv("DATACENTER_LOCATION")
 	tenantid := os.Getenv("ARM_TENANT_ID")
 	clientid := os.Getenv("ARM_CLIENT_ID")
-        clientsecret := os.Getenv("ARM_CLIENT_SECRET")
+	clientsecret := os.Getenv("ARM_CLIENT_SECRET")
 	subnetName := k8sName + "-subnet"
 	vnetName := k8sName + "-vnet"
 
@@ -41,20 +43,20 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	copy.Copy("../cluster/environments/azure-common-infra", azureCommonInfraFolder)
 
 	//Create the resource group
-        cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
-        err0 := cmd0.Run()
-        if err0 != nil {
-                fmt.Println("unable to login to azure cli")
-                log.Fatal(err0)
-                os.Exit(-1)
-        }
-        cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
-        err1 := cmd1.Run()
-        if err1 != nil {
-                fmt.Println("failed to create common resource group")
-                log.Fatal(err1)
-                os.Exit(-1)
-        }
+	cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
+	err0 := cmd0.Run()
+	if err0 != nil {
+		fmt.Println("unable to login to azure cli")
+		log.Fatal(err0)
+		os.Exit(-1)
+	}
+	cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
+	err1 := cmd1.Run()
+	if err1 != nil {
+		fmt.Println("failed to create common resource group")
+		log.Fatal(err1)
+		os.Exit(-1)
+	}
 
 	//Specify the test case folder and "-var" option mapping for the backend
 	common_backend_tfOptions := &terraform.Options{
@@ -72,13 +74,13 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 		TerraformDir: azureCommonInfraFolder,
 		Upgrade:      true,
 		Vars: map[string]interface{}{
-			"address_space":                  addressSpace,
-			"keyvault_name":                  kvName,
-			"global_resource_group_name":     kvRG,
-			"service_principal_id":           clientid,
-			"subnet_name":                    subnetName,
-			"subnet_prefix":                  addressSpace,
-			"vnet_name":                      vnetName,
+			"address_space":              addressSpace,
+			"keyvault_name":              kvName,
+			"global_resource_group_name": kvRG,
+			"service_principal_id":       clientid,
+			"subnet_name":                subnetName,
+			"subnet_prefix":              addressSpace,
+			"vnet_name":                  vnetName,
 		},
 	}
 
@@ -88,7 +90,7 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	terraform.Apply(t, common_tfOptions)
 
 	// Generate azure single environment using resources generated from common-infra
-        dnsprefix := k8sName + "-dns"
+	dnsprefix := k8sName + "-dns"
 	k8sRG := k8sName + "-rg"
 	publickey := os.Getenv("public_key")
 	sshkey := os.Getenv("ssh_key")
@@ -103,7 +105,7 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	cmd2 := exec.Command("az", "group", "create", "-n", k8sRG, "-l", location)
 	err2 := cmd2.Run()
 	if err2 != nil {
-                fmt.Println("failed to create cluster resource group")
+		fmt.Println("failed to create cluster resource group")
 		log.Fatal(err2)
 		os.Exit(-1)
 	}
@@ -133,6 +135,7 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 			"gitops_ssh_key":           sshkey,
 			"keyvault_name":            kvName,
 			"keyvault_resource_group":  kvRG,
+			"kubernetes_version":       k8sVersion,
 			"resource_group_name":      k8sRG,
 			"resource_group_location":  location,
 			"ssh_public_key":           publickey,

--- a/test/bedrock_Azure_single_cosmos_mongo_test.go
+++ b/test/bedrock_Azure_single_cosmos_mongo_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -28,7 +27,7 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	location := os.Getenv("DATACENTER_LOCATION")
 	tenantid := os.Getenv("ARM_TENANT_ID")
 	clientid := os.Getenv("ARM_CLIENT_ID")
-	clientsecret := os.Getenv("ARM_CLIENT_SECRET")
+        clientsecret := os.Getenv("ARM_CLIENT_SECRET")
 	subnetName := k8sName + "-subnet"
 	vnetName := k8sName + "-vnet"
 
@@ -43,20 +42,20 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	copy.Copy("../cluster/environments/azure-common-infra", azureCommonInfraFolder)
 
 	//Create the resource group
-	cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
-	err0 := cmd0.Run()
-	if err0 != nil {
-		fmt.Println("unable to login to azure cli")
-		log.Fatal(err0)
-		os.Exit(-1)
-	}
-	cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
-	err1 := cmd1.Run()
-	if err1 != nil {
-		fmt.Println("failed to create common resource group")
-		log.Fatal(err1)
-		os.Exit(-1)
-	}
+        cmd0 := exec.Command("az", "login", "--service-principal", "-u", clientid, "-p", clientsecret, "--tenant", tenantid)
+        err0 := cmd0.Run()
+        if err0 != nil {
+                fmt.Println("unable to login to azure cli")
+                log.Fatal(err0)
+                os.Exit(-1)
+        }
+        cmd1 := exec.Command("az", "group", "create", "-n", kvRG, "-l", location)
+        err1 := cmd1.Run()
+        if err1 != nil {
+                fmt.Println("failed to create common resource group")
+                log.Fatal(err1)
+                os.Exit(-1)
+        }
 
 	//Specify the test case folder and "-var" option mapping for the backend
 	common_backend_tfOptions := &terraform.Options{
@@ -74,13 +73,13 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 		TerraformDir: azureCommonInfraFolder,
 		Upgrade:      true,
 		Vars: map[string]interface{}{
-			"address_space":              addressSpace,
-			"keyvault_name":              kvName,
-			"global_resource_group_name": kvRG,
-			"service_principal_id":       clientid,
-			"subnet_name":                subnetName,
-			"subnet_prefix":              addressSpace,
-			"vnet_name":                  vnetName,
+			"address_space":                  addressSpace,
+			"keyvault_name":                  kvName,
+			"global_resource_group_name":     kvRG,
+			"service_principal_id":           clientid,
+			"subnet_name":                    subnetName,
+			"subnet_prefix":                  addressSpace,
+			"vnet_name":                      vnetName,
 		},
 	}
 
@@ -90,7 +89,7 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	terraform.Apply(t, common_tfOptions)
 
 	// Generate azure single environment using resources generated from common-infra
-	dnsprefix := k8sName + "-dns"
+        dnsprefix := k8sName + "-dns"
 	k8sRG := k8sName + "-rg"
 	publickey := os.Getenv("public_key")
 	sshkey := os.Getenv("ssh_key")
@@ -105,7 +104,7 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	cmd2 := exec.Command("az", "group", "create", "-n", k8sRG, "-l", location)
 	err2 := cmd2.Run()
 	if err2 != nil {
-		fmt.Println("failed to create cluster resource group")
+                fmt.Println("failed to create cluster resource group")
 		log.Fatal(err2)
 		os.Exit(-1)
 	}
@@ -135,7 +134,7 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 			"gitops_ssh_key":           sshkey,
 			"keyvault_name":            kvName,
 			"keyvault_resource_group":  kvRG,
-			"kubernetes_version":       k8sVersion,
+                        "kubernetes_version":       k8sVersion,
 			"resource_group_name":      k8sRG,
 			"resource_group_location":  location,
 			"ssh_public_key":           publickey,


### PR DESCRIPTION
Adds `kubernetes_version` to each environment such that, as part of day 2 operations, you can do Kubernetes upgrades.  In talking over #861 it was decided that explicitly specifying a version was better than using a script, as a script could potentially pull in a new default version for K8s in a way that is opaque for the operator.

Closes #861 