### PR TITLE
Removing triage from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ""
-labels: bug, triage
+labels: bug
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ""
-labels: enhancement, triage
+labels: enhancement
 assignees: ""
 ---
 


### PR DESCRIPTION
We don’t seem to use `triage` label on GitHub Issue at all in SPK or Bedrock. Almost every issue has `triage` on it. At this point it is just noise. Removing it 