### PR TITLE
fix for Unzip package

### DIFF
--- a/tools/prereqs/setup_terraform.sh
+++ b/tools/prereqs/setup_terraform.sh
@@ -33,6 +33,7 @@ if [ "$ostype" == "linux" ]; then
     sudo apt-get install unzip
 elif [ "$ostype" == "macos" ]; then
     arch="darwin_amd64"
+    brew install unzip
 else
     echo "OS ($ostype) not supported."
     exit 1

--- a/tools/prereqs/setup_terraform.sh
+++ b/tools/prereqs/setup_terraform.sh
@@ -30,6 +30,7 @@ cd $tmp_dir
 ostype=`os_type`
 if [ "$ostype" == "linux" ]; then
     arch="linux_amd64"
+    sudo apt-get install unzip
 elif [ "$ostype" == "macos" ]; then
     arch="darwin_amd64"
 else
@@ -40,7 +41,6 @@ fi
 TERRAFORM_VERSION=`curl -L -s https://github.com/hashicorp/terraform/releases/latest | grep archive | grep zip | awk -F"/v" '{print $2}' | awk -F".zip" '{print $1}'`
 curl -LO -s https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_"$TERRAFORM_VERSION"_$arch.zip
 
-sudo apt-get install unzip
 unzip terraform_"$TERRAFORM_VERSION"_$arch.zip -d /usr/local/bin/
 
 echo "terraform installed in /usr/local/bin"

--- a/tools/prereqs/setup_terraform.sh
+++ b/tools/prereqs/setup_terraform.sh
@@ -15,7 +15,7 @@ trap finish EXIT
 
 # prompt for confirmation
 echo "This script will install the latest version of Terraform from github."
-read -p "Do you wish to continue? " -n 1 -r
+read -p "Do you wish to continue? (y or n)" -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
@@ -40,6 +40,7 @@ fi
 TERRAFORM_VERSION=`curl -L -s https://github.com/hashicorp/terraform/releases/latest | grep archive | grep zip | awk -F"/v" '{print $2}' | awk -F".zip" '{print $1}'`
 curl -LO -s https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_"$TERRAFORM_VERSION"_$arch.zip
 
+sudo apt-get install unzip
 unzip terraform_"$TERRAFORM_VERSION"_$arch.zip -d /usr/local/bin/
 
 echo "terraform installed in /usr/local/bin"


### PR DESCRIPTION
Fix - Script produces an error message: unzip not found.   This command will fail in base WSL an Unzip package is not installed by default.  

closes https://github.com/microsoft/bedrock/issues/1240