### PR TITLE
create-variable-group documentation cleanup

### DIFF
--- a/docs/rings.md
+++ b/docs/rings.md
@@ -33,7 +33,7 @@ rings:
   master:
     isDefault: true
 services:
-  ./azure-vote:
+  - path: ./azure-vote
     displayName: azure-voting-app
     helm:
       chart:


### PR DESCRIPTION
- Added scripts to re-use previously used service principal credentials
  mentioned and saved in infrastructure deployment guides.

closes https://github.com/microsoft/bedrock/issues/1225