### PR TITLE
Fixing the az storage account creation command in single-cluster.md

### DIFF
--- a/docs/single-cluster.md
+++ b/docs/single-cluster.md
@@ -30,7 +30,7 @@ az storage account create \
     --resource-group my-global-rg \
     --location eastus \
     --sku Standard_LRS \
-    --encryption blob
+    --encryption-services blob
 ```
 
 The Azure CLI needs your storage account credentials for most of the commands in this tutorial. While there are several options for doing so, one of the easiest ways to provide them is to set `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` environment variables.


### PR DESCRIPTION
I was doing the single cluster walkthrough and got an error when running:

```
az storage account create \
    --name mystorageaccount \
    --resource-group my-global-rg \
    --location eastus \
    --sku Standard_LRS \
    --encryption-services blob
```
error: az storage account create: error: ambiguous option: --encryption could match --encryption-services, --encryption-key-type-for-table, --encryption-key-type-for-queue

Looks like the --encryption option has changed to --encryption-services as per: https://docs.microsoft.com/en-us/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-create