### PR TITLE
fail pipeline if git clone fails

### DIFF
--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -194,6 +194,7 @@ function git_connect() {
 
     echo "GIT CLONE: https://automated:<ACCESS_TOKEN_SECRET>@$repo_url"
     git clone "https://automated:$ACCESS_TOKEN_SECRET@$repo_url"
+    retVal=$? && [ $retVal -ne 0 ] && exit $retVal
 
     # Extract repo name from url
     repo_url=$REPO


### PR DESCRIPTION
Fixes #1357 

This PR fails if can't clone the repository which enables the pipeline to give a valid error message for the user to debug in the pipeline output. 