### PR TITLE
Updating AKS environments to k8s from 1.15.7 to 1.15.11

### DIFF
--- a/cluster/environments/azure-msi/variables.tf
+++ b/cluster/environments/azure-msi/variables.tf
@@ -57,7 +57,7 @@ variable "gitops_url_branch" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.15.7"
+  default = "1.15.11"
 }
 
 variable "resource_group_name" {

--- a/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-variables.tf
+++ b/cluster/environments/azure-multiple-clusters-waf-tm-apimgmt/aks-variables.tf
@@ -13,7 +13,7 @@ variable "dns_prefix" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.15.7"
+  default = "1.15.11"
 }
 
 variable "ssh_public_key" {

--- a/cluster/environments/azure-multiple-clusters/aks-variables.tf
+++ b/cluster/environments/azure-multiple-clusters/aks-variables.tf
@@ -17,7 +17,7 @@ variable "dns_prefix" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.15.7"
+  default = "1.15.11"
 }
 
 variable "ssh_public_key" {

--- a/cluster/environments/azure-simple/variables.tf
+++ b/cluster/environments/azure-simple/variables.tf
@@ -52,7 +52,7 @@ variable "gitops_url_branch" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.15.7"
+  default = "1.15.11"
 }
 
 variable "resource_group_name" {

--- a/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/variables.tf
+++ b/cluster/environments/azure-single-keyvault-cosmos-mongo-db-simple/variables.tf
@@ -72,7 +72,7 @@ variable "keyvault_resource_group" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.15.7"
+  default = "1.15.11"
 }
 
 variable "resource_group_name" {

--- a/cluster/environments/azure-single-keyvault/variables.tf
+++ b/cluster/environments/azure-single-keyvault/variables.tf
@@ -68,7 +68,7 @@ variable "keyvault_resource_group" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.15.7"
+  default = "1.15.11"
 }
 
 variable "resource_group_name" {

--- a/cluster/environments/azure-velero-restore/variables.tf
+++ b/cluster/environments/azure-velero-restore/variables.tf
@@ -78,7 +78,7 @@ variable "keyvault_resource_group" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.15.7"
+  default = "1.15.11"
 }
 
 variable "resource_group_name" {

--- a/docs/single-cluster.md
+++ b/docs/single-cluster.md
@@ -202,7 +202,7 @@ variables:
   gitops_path: <insert value>
   keyvault_name: <insert value>
   keyvault_resource_group: <insert value>
-  kubernetes_version: 1.15.7
+  kubernetes_version: 1.15.11
   resource_group_name: <insert value>
   ssh_public_key: <insert value>
   service_principal_id: <insert value>
@@ -264,7 +264,7 @@ variables:
   vnet_name: 'myvnet'
   service_principal_id: '46b1b7dc-168a-ccc-bbb-aaaaaaa'
   service_principal_secret: 'aaaa-bbbb-43eb-9ead-dddddd'
-  kubernetes_version: '1.15.7'
+  kubernetes_version: '1.15.11'
   subnet_name: 'mysubnet'
   subnet_prefix: 10.8.0.0/24
   network_plugin: azure

--- a/docs/singleKeyvault/README.md
+++ b/docs/singleKeyvault/README.md
@@ -200,7 +200,7 @@ variables:
   gitops_path: <insert value>
   keyvault_name: <insert value>
   keyvault_resource_group: <insert value>
-  kubernetes_version: 1.15.7
+  kubernetes_version: 1.15.11
   resource_group_name: <insert value>
   ssh_public_key: <insert value>
   service_principal_id: <insert value>
@@ -262,7 +262,7 @@ variables:
   vnet_name: 'myvnet'
   service_principal_id: '46b1b7dc-168a-ccc-bbb-aaaaaaa'
   service_principal_secret: 'aaaa-bbbb-43eb-9ead-dddddd'
-  kubernetes_version: '1.15.7'
+  kubernetes_version: '1.15.11'
   subnet_name: 'mysubnet'
   service_cidr: 10.0.0.0/16
   dns_ip: 10.0.0.10

--- a/test/bedrock_Azure_common_kv_test.go
+++ b/test/bedrock_Azure_common_kv_test.go
@@ -24,7 +24,7 @@ func TestIT_Bedrock_AzureCommon_KV_Test(t *testing.T) {
 	addressSpace := "10.39.0.0/16"
 	kvName := k8sName + "-kv"
 	kvRG := kvName + "-rg"
-	k8sVersion := "1.15.7"
+	k8sVersion := "1.15.11"
 
 	location := os.Getenv("DATACENTER_LOCATION")
 	clientid := os.Getenv("ARM_CLIENT_ID")

--- a/test/bedrock_Azure_mc_test.go
+++ b/test/bedrock_Azure_mc_test.go
@@ -41,7 +41,7 @@ func TestIT_Bedrock_AzureMC_Test(t *testing.T) {
 	// Generate a common infra resources for integration use with azure multicluster environment
 	uniqueID := strings.ToLower(random.UniqueId())
 	k8sName := fmt.Sprintf("gtestk8s-%s", uniqueID)
-	k8sVersion := "1.15.7"
+	k8sVersion := "1.15.11"
 
 	location := os.Getenv("DATACENTER_LOCATION")
 	clientid := os.Getenv("ARM_CLIENT_ID")

--- a/test/bedrock_Azure_simple_test.go
+++ b/test/bedrock_Azure_simple_test.go
@@ -29,7 +29,7 @@ func TestIT_Bedrock_AzureSimple_Test(t *testing.T) {
 	tenantId := os.Getenv("ARM_TENANT_ID")
 	dnsprefix := k8sName + "-dns"
 	k8sRG := k8sName + "-rg"
-	k8sVersion := "1.15.7"
+	k8sVersion := "1.15.11"
 	location := os.Getenv("DATACENTER_LOCATION")
 	publickey := os.Getenv("public_key")
 	sshkey := os.Getenv("ssh_key")

--- a/test/bedrock_Azure_single_cosmos_mongo_test.go
+++ b/test/bedrock_Azure_single_cosmos_mongo_test.go
@@ -25,7 +25,7 @@ func TestIT_Bedrock_Azure_Single_KV_Cosmos_Mongo_DB_Test(t *testing.T) {
 	addressSpace := "10.39.0.0/16"
 	kvName := k8sName + "-kv"
 	kvRG := kvName + "-rg"
-	k8sVersion := "1.15.7"
+	k8sVersion := "1.15.11"
 	location := os.Getenv("DATACENTER_LOCATION")
 	tenantid := os.Getenv("ARM_TENANT_ID")
 	clientid := os.Getenv("ARM_CLIENT_ID")


### PR DESCRIPTION
Ran into deployment issues with the current default `1.15.7` k8s version:

```sh
Error: Error creating Managed Kubernetes Cluster "..." (Resource Group "..."): containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.15.7 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list"
```

To get latest aks versions:
`az aks get-versions --location eastus --output table`
