### PR TITLE
Avoid recreating resources when not needed

### DIFF
--- a/cluster/azure/aks/main.tf
+++ b/cluster/azure/aks/main.tf
@@ -119,11 +119,14 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 }
 
 data "external" "msi_object_id" {
-  depends_on = [azurerm_kubernetes_cluster.cluster]
   program = [
     "${path.module}/aks_msi_client_id_query.sh",
     var.cluster_name,
     data.azurerm_resource_group.cluster.name,
     data.azurerm_subscription.current.subscription_id
   ]
+
+  query = {
+    clusterid = azurerm_kubernetes_cluster.cluster.id
+  }
 }


### PR DESCRIPTION
Sub-sequent calls to `terraform plan` or `terraform apply` against an already provisioned cluster recreates the ACR pull role assignment for the Managed Identity.

As per the discussion over at https://github.com/hashicorp/terraform/issues/22005 this fix will mitigate that behaviour.

The added `query` section is merely there to create an implicit dependency between the cluster resource and the msi_object_id resource which will move the read from the apply-phase to the plan phase where it will evaluate to a non-changed value.