### PR TITLE
Update AKS module output to include kube config file path

### DIFF
--- a/cluster/azure/aks/outputs.tf
+++ b/cluster/azure/aks/outputs.tf
@@ -8,6 +8,10 @@ output "kube_config" {
   value     = azurerm_kubernetes_cluster.cluster.kube_config_raw
 }
 
+output "kube_config_file_path" {
+  value = local_file.cluster_credentials.0.filename
+}
+
 output "kubeconfig_done" {
   value = join("", local_file.cluster_credentials.*.id)
 }


### PR DESCRIPTION
Adds `kube_config_file_path` to aks module output.

Closes #1448 