### PR TITLE
Change build.sh script to point to Helm 2 compatible version of Fabrikate

### DIFF
--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -28,13 +28,19 @@ function helm_init() {
 }
 
 # Obtain version for Fabrikate
-# If the version number is not provided, then download the latest
+# If the version number is not provided, then download the latest Helm2 compatible version
 function get_fab_version() {
     # shellcheck disable=SC2153
     if [ -z "$VERSION" ]
     then
-        # By default, the script will use the most recent non-prerelease, non-draft release Fabrikate
-        VERSION_TO_DOWNLOAD=$(curl -s "https://api.github.com/repos/microsoft/fabrikate/releases/latest" | grep "tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
+        # By default, the script will use the Helm 2 compatible, non-prerelease, non-draft release Fabrikate
+        MAJOR=${1:-0} 
+        VERSIONS=$(curl -s "https://api.github.com/repos/microsoft/fabrikate/git/matching-refs/tags/$MAJOR" | grep "/refs/tags/$MAJOR" | while read -r line ; do
+            VERSION=${line##*/}
+            VERSION=${VERSION%\",}
+            echo "$VERSION"
+        done | sort -V)
+        VERSION_TO_DOWNLOAD=${VERSIONS##*$'\n'}
     else
         echo "Fabrikate Version: $VERSION"
         VERSION_TO_DOWNLOAD=$VERSION

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -36,13 +36,13 @@ function get_fab_version() {
     then
         # By default, the script will use the Helm 2 compatible, non-prerelease, non-draft release Fabrikate.
         MAJOR=${1:-0} 
-        MAJOR="v$MAJOR"
         VERSIONS=$(curl -s "https://api.github.com/repos/microsoft/fabrikate/git/matching-refs/tags/$MAJOR" | grep "/refs/tags/$MAJOR" | while read -r line ; do
             VERSION=${line##*/}
             VERSION=${VERSION%\",}
             echo "$VERSION"
         done | sort -V)
         VERSION_TO_DOWNLOAD=${VERSIONS##*$'\n'}
+        echo $VERSION_TO_DOWNLOAD
     else
         echo "Fabrikate Version: $VERSION"
         VERSION_TO_DOWNLOAD=$VERSION

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -29,12 +29,14 @@ function helm_init() {
 
 # Obtain version for Fabrikate
 # If the version number is not provided, then download the latest Helm2 compatible version
+# The Major version number can be provided as the first argument, 
 function get_fab_version() {
     # shellcheck disable=SC2153
     if [ -z "$VERSION" ]
     then
-        # By default, the script will use the Helm 2 compatible, non-prerelease, non-draft release Fabrikate
+        # By default, the script will use the Helm 2 compatible, non-prerelease, non-draft release Fabrikate.
         MAJOR=${1:-0} 
+        MAJOR="v$MAJOR"
         VERSIONS=$(curl -s "https://api.github.com/repos/microsoft/fabrikate/git/matching-refs/tags/$MAJOR" | grep "/refs/tags/$MAJOR" | while read -r line ; do
             VERSION=${line##*/}
             VERSION=${VERSION%\",}


### PR DESCRIPTION
Closes #1412 

Instead of the most recent version of Fabrikate, the script will now point to the most recent MAJOR version of 0.x.x
This ensures that bedrock is using a Helm 2 compatible version of Fabrikate.