### PR TITLE
flux is polling the master branch instead on main

### DIFF
--- a/cluster/common/flux/variables.tf
+++ b/cluster/common/flux/variables.tf
@@ -38,7 +38,7 @@ variable "gitops_ssh_url" {
 variable "gitops_url_branch" {
   description = "Git branch associated with the gitops_ssh_url where flux checks for the raw kubernetes yaml files to deploy to the cluster."
   type        = string
-  default     = "master"
+  default     = "main"
 }
 
 variable "acr_enabled" {


### PR DESCRIPTION
New branches being created in the project are named as "main" instead on "master". Default behaviour of flux is to still poll the "master" branch. Changed gitops_url_branch variable's default value from "master" to "main" in  cluster/common/flux/variables.tf.
