### PR TITLE
Manifest diff as a PR comment for AzDO 

### DIFF
--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -216,6 +216,7 @@ function manifest_diff_into_pr() {
         echo "${arr[4]}"
         echo "${arr[2]}"
         echo "${arr[1]}"
+        echo $MESSAGE
 
         echo "curl \"https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0\" -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\"description\": \"$MESSAGE\"}\""
         

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -216,7 +216,7 @@ function manifest_diff_into_pr() {
         # echo "${arr[4]}"
         # echo "${arr[2]}"
         # echo "${arr[1]}"
-        # MESSAGE=$(awk '$1=$1' ORS=' \\n ' diff.txt)
+        MESSAGE=$(awk '$1=$1' ORS=' \\n ' diff.txt)
         MESSAGE=$(echo ${MESSAGE:0:4000})
         echo $MESSAGE
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -224,20 +224,20 @@ function manifest_diff_into_pr() {
         url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullRequests/$1/threads?api-version=6.0"
         
 
-        echo "\ntry 2"
-        echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
-        curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
+        # echo "\ntry 2"
+        # echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
+        # curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
 
         echo "\ntry 3"
         echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}\""
         curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
 
-        echo "\n------------------------------------------------------------"
-        JSON_STRING=$( jq -n --arg comment "$MESSAGE"  \
-                  '{comments: [ { content: $comment  } ] }' )
-        echo "curl -X POST $url  -H \"Content-Type:application/json\" --data \"$JSON_STRING\" -H \"Authorization: Basic $encoded_token\""
-        curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
-        echo "\n------------------------------------------------------------"
+        # echo "\n------------------------------------------------------------"
+        # JSON_STRING=$( jq -n --arg comment "$MESSAGE"  \
+        #           '{comments: [ { content: $comment  } ] }' )
+        # echo "curl -X POST $url  -H \"Content-Type:application/json\" --data \"$JSON_STRING\" -H \"Authorization: Basic $encoded_token\""
+        # curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
+        # echo "\n------------------------------------------------------------"
 
     else
         echo "Manifest generation files will not be modified at all."

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -188,6 +188,7 @@ function manifest_diff_into_pr() {
         git diff | tee -a diff.txt
         echo "\\\`\\\`\\\`" >> diff.txt
         MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
+        MESSAGE=$(echo "${MESSAGE//--/}")
         echo "az repos pr update --id $1 --description $(echo ${MESSAGE:0:4000})"
 
         # description only allows 4000 characters at max

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -224,11 +224,19 @@ function manifest_diff_into_pr() {
         url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullRequests/$1/threads?api-version=6.0"
 
         echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
-        
+
+        echo "try 1"
         cmd="curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
+        echo $cmd
         eval "$cmd"
         
+        echo "try 2"
+        echo curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
         curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
+
+        echo "try 3"
+        echo curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
+        curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
 
         # echo "curl $url -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\\\"description\\\": \\\"$MESSAGE\\\"}\""
         

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -184,8 +184,9 @@ function manifest_diff_into_pr() {
 
     if [[ $(git status --porcelain) ]]; then
         echo "The following diff will be applied to cluster-manifests upon merge:" > diff.txt
+        echo \`\`\`diff >> diff.txt
         git diff | tee -a diff.txt
-        cat diff.txt
+        echo \`\`\` >> diff.txt
         MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
         echo "az repos pr update --id $1 --description $(echo ${MESSAGE:0:4000})"
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -196,15 +196,15 @@ function manifest_diff_into_pr() {
     if [[ $(git status --porcelain) ]]; then
         echo "The following diff will be applied to cluster-manifests upon merge:" > diff.txt
         # echo "\\\`\\\`\\\`diff" >> diff.txt
-        echo "\`\`\`diff" >> diff.txt
+        echo "\\\`\\\`\\\`diff" >> diff.txt
         git diff | tee -a diff.txt
-        echo "\`\`\`" >> diff.txt
+        echo "\\\`\\\`\\\`" >> diff.txt
         # echo "\\\`\\\`\\\`" >> diff.txt
         # MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
         # description only allows 4000 characters at max
         MESSAGE=$(cat diff.txt)
         MESSAGE=$(echo ${MESSAGE:0:4000})
-        encoded_token=$(echo -n ':$ACCESS_TOKEN_SECRET' |  base64)
+        encoded_token=$(echo -n ":$ACCESS_TOKEN_SECRET" |  base64)
 
         # echo "az repos pr update --id $1 --description $(echo ${MESSAGE:0:4000})"
         # az repos pr update --id $1 --description $(echo ${MESSAGE:0:4000})
@@ -219,9 +219,11 @@ function manifest_diff_into_pr() {
         echo "${arr[1]}"
         echo $MESSAGE
 
-        echo "curl \"https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0\" -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\"description\": \"$MESSAGE\"}\""
+        url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0"
+
+        echo "curl $url -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\"description\": \"$MESSAGE\"}\""
         
-        curl "https://dev.azure.com/${a[2]}/${a[3]}/_apis/git/repositories/${a[5]}/pullrequests/$1\?api-version\=6.0" -X PATCH -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{\"description\": \"$MESSAGE\"}"
+        curl $url -X PATCH -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{\"description\": \"$MESSAGE\"}" 
     else
         echo "Manifest generation files will not be modified at all."
         az repos pr update --id $1 --description "Manifest generation files will not be modified at all."

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -184,9 +184,9 @@ function manifest_diff_into_pr() {
 
     if [[ $(git status --porcelain) ]]; then
         echo "The following diff will be applied to cluster-manifests upon merge:" > diff.txt
-        echo \`\`\`diff >> diff.txt
+        echo "\\\`\\\`\\\`diff" >> diff.txt
         git diff | tee -a diff.txt
-        echo \`\`\` >> diff.txt
+        echo "\\\`\\\`\\\`" >> diff.txt
         MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
         echo "az repos pr update --id $1 --description $(echo ${MESSAGE:0:4000})"
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -221,9 +221,9 @@ function manifest_diff_into_pr() {
 
         url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0"
 
-        echo "curl $url -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\"description\": \"$MESSAGE\"}\""
+        echo "curl $url -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\\\"description\\\": \\\"$MESSAGE\\\"}\""
         
-        curl $url -X PATCH -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{\"description\": \"$MESSAGE\"}" 
+        curl $url -X PATCH -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{\\\"description\\\": \\\"$MESSAGE\\\"}" 
     else
         echo "Manifest generation files will not be modified at all."
         az repos pr update --id $1 --description "Manifest generation files will not be modified at all."

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -216,7 +216,7 @@ function manifest_diff_into_pr() {
         # echo "${arr[4]}"
         # echo "${arr[2]}"
         # echo "${arr[1]}"
-        MESSAGE=$(awk '$1=$1' ORS=' \\n ' diff.txt)
+        MESSAGE=$(awk '$1=$1' ORS=' \n ' diff.txt)
         MESSAGE=$(echo ${MESSAGE:0:4000})
         echo $MESSAGE
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -74,8 +74,9 @@ function download_fab() {
     else
         echo "There was an error when downloading Fabrikate. Please check version number and try again."
     fi
-    wget "https://github.com/Microsoft/fabrikate/releases/download/$VERSION_TO_DOWNLOAD/fab-v$VERSION_TO_DOWNLOAD-$os-amd64.zip"
-    unzip "fab-v$VERSION_TO_DOWNLOAD-$os-amd64.zip" -d fab
+    filename=$(uuidgen)
+    wget -q -O "$filename.zip" "https://github.com/Microsoft/fabrikate/releases/download/$VERSION_TO_DOWNLOAD/fab-v$VERSION_TO_DOWNLOAD-$os-amd64.zip"
+    unzip "$filename.zip" -d fab
 
     export PATH=$PATH:$HOME/fab
 }
@@ -155,7 +156,8 @@ function manifest_diff_into_pr() {
     echo $1
     echo $2 
     HLD_BRANCH=$2
-
+    
+    download_fab
     install_fab
     fab_generate
     git_connect
@@ -230,13 +232,13 @@ function download_spk() {
     echo "Deprecated SPK Version: $SPK_VERSION_TO_DOWNLOAD"
     os=''
     get_os_bedrock os
-    spk_wget=$(wget -SO- "https://github.com/microsoft/bedrock-cli/releases/download/$SPK_VERSION_TO_DOWNLOAD/spk-$os" 2>&1 | grep -E -i "302")
+    spk_wget=$(wget -q -SO- "https://github.com/microsoft/bedrock-cli/releases/download/$SPK_VERSION_TO_DOWNLOAD/spk-$os" 2>&1 | grep -E -i "302")
     if [[ $spk_wget == *"302 Found"* ]]; then
     echo "SPK $SPK_VERSION_TO_DOWNLOAD downloaded successfully."
     else
         echo "There was an error when downloading SPK. Please check version number and try again."
     fi
-    wget "https://github.com/microsoft/bedrock-cli/releases/download/$SPK_VERSION_TO_DOWNLOAD/spk-$os"
+    wget -q "https://github.com/microsoft/bedrock-cli/releases/download/$SPK_VERSION_TO_DOWNLOAD/spk-$os"
     mkdir spk
     mv spk-$os spk/spk
     chmod +x spk/spk 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -208,13 +208,16 @@ function manifest_diff_into_pr() {
         # echo "az repos pr update --id $1 --description $(echo ${MESSAGE:0:4000})"
         # az repos pr update --id $1 --description $(echo ${MESSAGE:0:4000})
 
+        # IFS='/' read -r -a arr <<< "$HLD_PATH"
         HLD_PATH="${HLD_PATH#http://}"
         HLD_PATH="${HLD_PATH#https://}"
         arr=($(echo "$HLD_PATH" | tr '/' '\n'))
         echo "HLD_PATH=$HLD_PATH"
-        echo $arr
+        echo "${arr[4]}"
+        echo "${arr[2]}"
+        echo "${arr[1]}"
 
-        echo "curl \"https://dev.azure.com/${a[2]}/${a[3]}/_apis/git/repositories/${a[5]}/pullrequests/$1\?api-version\=6.0\" -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\"description\": \"$MESSAGE\"}\""
+        echo "curl \"https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0\" -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\"description\": \"$MESSAGE\"}\""
         
         curl "https://dev.azure.com/${a[2]}/${a[3]}/_apis/git/repositories/${a[5]}/pullrequests/$1\?api-version\=6.0" -X PATCH -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{\"description\": \"$MESSAGE\"}"
     else

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -202,6 +202,7 @@ function manifest_diff_into_pr() {
         # echo "\\\`\\\`\\\`" >> diff.txt
         # MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
         # description only allows 4000 characters at max
+        MESSAGE=$(cat diff.txt)
         MESSAGE=$(echo ${MESSAGE:0:4000})
         encoded_token=$(echo -n ':$ACCESS_TOKEN_SECRET' |  base64)
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -68,7 +68,7 @@ function download_fab() {
     echo "Latest Fabrikate Version: $VERSION_TO_DOWNLOAD"
     os=''
     get_os os
-    fab_wget=$(wget -q -SO- "https://github.com/Microsoft/fabrikate/releases/download/$VERSION_TO_DOWNLOAD/fab-v$VERSION_TO_DOWNLOAD-$os-amd64.zip" 2>&1 | grep -E -i "302")
+    fab_wget=$(wget -SO- "https://github.com/Microsoft/fabrikate/releases/download/$VERSION_TO_DOWNLOAD/fab-v$VERSION_TO_DOWNLOAD-$os-amd64.zip" 2>&1 | grep -E -i "302")
     if [[ $fab_wget == *"302 Found"* ]]; then
        echo "Fabrikate $VERSION_TO_DOWNLOAD downloaded successfully."
     else
@@ -232,7 +232,7 @@ function download_spk() {
     echo "Deprecated SPK Version: $SPK_VERSION_TO_DOWNLOAD"
     os=''
     get_os_bedrock os
-    spk_wget=$(wget -q -SO- "https://github.com/microsoft/bedrock-cli/releases/download/$SPK_VERSION_TO_DOWNLOAD/spk-$os" 2>&1 | grep -E -i "302")
+    spk_wget=$(wget -SO- "https://github.com/microsoft/bedrock-cli/releases/download/$SPK_VERSION_TO_DOWNLOAD/spk-$os" 2>&1 | grep -E -i "302")
     if [[ $spk_wget == *"302 Found"* ]]; then
     echo "SPK $SPK_VERSION_TO_DOWNLOAD downloaded successfully."
     else
@@ -258,7 +258,7 @@ function download_bedrock() {
     else
         echo "There was an error when downloading Bedrock CLI. Please check version number and try again."
     fi
-    wget "https://github.com/microsoft/bedrock-cli/releases/download/$CLI_VERSION_TO_DOWNLOAD/bedrock-$os"
+    wget -q "https://github.com/microsoft/bedrock-cli/releases/download/$CLI_VERSION_TO_DOWNLOAD/bedrock-$os"
     mkdir bedrock
     mv bedrock-$os bedrock/bedrock
     chmod +x bedrock/bedrock 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -220,12 +220,23 @@ function manifest_diff_into_pr() {
         MESSAGE=$(echo ${MESSAGE:0:4000})
         echo $MESSAGE
 
+        # url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0"
         url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullRequests/$1/threads?api-version=6.0"
-
+        echo "------------------------------------------------------------"
         JSON_STRING=$( jq -n --arg comment "$MESSAGE"  \
                   '{comments: [ { content: $comment  } ] }' )
-        echo curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
+        echo "curl -X POST $url  -H \"Content-Type:application/json\" --data \"$JSON_STRING\" -H \"Authorization: Basic $encoded_token\""
         curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
+        echo "------------------------------------------------------------"
+
+        echo "\ntry 2"
+        echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
+        curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
+
+        echo "\ntry 3"
+        echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}\""
+        curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
+
     else
         echo "Manifest generation files will not be modified at all."
         az repos pr update --id $1 --description "Manifest generation files will not be modified at all."

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -203,10 +203,7 @@ function manifest_diff_into_pr() {
 
         # separate them out by new line characters
         MESSAGE=$(awk '$1=$1' ORS=' \\n ' diff.txt)
-
-        # description only allows 4000 characters at max
-        MESSAGE=$(echo ${MESSAGE:0:4000})
-        echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}\""
+        
         curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
     else
         echo "Manifest generation files will not be modified at all."

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -216,7 +216,7 @@ function manifest_diff_into_pr() {
         # echo "${arr[4]}"
         # echo "${arr[2]}"
         # echo "${arr[1]}"
-        MESSAGE=$(awk '$1=$1' ORS=' \n ' diff.txt)
+        MESSAGE=$(awk '$1=$1' ORS=' \\n ' diff.txt)
         MESSAGE=$(echo ${MESSAGE:0:4000})
         echo $MESSAGE
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -94,6 +94,9 @@ function install_hld() {
 
     # if branch name is specified, switch to that HLD branch 
     if [ -z "$HLD_BRANCH" ]; then
+        echo "HLD_BRANCH is not specified, skip changing branch"
+    else
+        echo "Switching to HLD branch $HLD_BRANCH"
         git checkout $HLD_BRANCH
     fi
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -211,6 +211,8 @@ function manifest_diff_into_pr() {
         HLD_PATH="${HLD_PATH#http://}"
         HLD_PATH="${HLD_PATH#https://}"
         arr=($(echo "$HLD_PATH" | tr '/' '\n'))
+        echo "HLD_PATH=$HLD_PATH"
+        echo $arr
 
         echo "curl \"https://dev.azure.com/${a[2]}/${a[3]}/_apis/git/repositories/${a[5]}/pullrequests/$1\?api-version\=6.0\" -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\"description\": \"$MESSAGE\"}\""
         

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -195,12 +195,12 @@ function manifest_diff_into_pr() {
 
     encoded_token=$(echo -n ":$ACCESS_TOKEN_SECRET" |  base64)
 
-    url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullRequests/$1/threads?api-version=6.0"
-
     # Break down the HLD path to extract org, project and repo name
     HLD_PATH="${HLD_PATH#http://}"
     HLD_PATH="${HLD_PATH#https://}"
     arr=($(echo "$HLD_PATH" | tr '/' '\n'))
+
+    url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullRequests/$1/threads?api-version=6.0"
     
     if [[ $(git status --porcelain) ]]; then
         echo "The following diff will be applied to cluster-manifests upon merge:" > diff.txt
@@ -213,9 +213,8 @@ function manifest_diff_into_pr() {
 
         # description only allows 4000 characters at max
         MESSAGE=$(echo ${MESSAGE:0:4000})
-        
+        echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}\""
         curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
-
     else
         echo "Manifest generation files will not be modified at all."
         curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"Manifest generation files will not be modified at all.\" } ]}"

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -167,8 +167,6 @@ function fab_generate() {
 }
 
 function manifest_diff_into_pr() {
-    echo $1
-    echo $2 
     HLD_BRANCH=$2
     
     download_fab
@@ -176,21 +174,16 @@ function manifest_diff_into_pr() {
     fab_generate
     git_connect
 
-    ls -al 
-    echo "about to replace manifests with new ones"
     rm -rf */
 
     if [ -z "$FAB_ENVS" ]; then
         cp -a $manifest_files_location. .
-        ls -al 
     else
         IFS=',' read -ra ENV <<< "$FAB_ENVS"
         for i in "${ENV[@]}"
         do
         cp -R ../generated/$i ./
         done
-        
-        ls -al 
     fi
 
     encoded_token=$(echo -n ":$ACCESS_TOKEN_SECRET" |  base64)

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -216,27 +216,40 @@ function manifest_diff_into_pr() {
         echo "${arr[4]}"
         echo "${arr[2]}"
         echo "${arr[1]}"
-        MESSAGE=$(awk '$1=$1' ORS=' \\n ' diff.txt)
+        # MESSAGE=$(awk '$1=$1' ORS=' \\n ' diff.txt)
         MESSAGE=$(echo ${MESSAGE:0:4000})
         echo $MESSAGE
 
         # url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0"
         url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullRequests/$1/threads?api-version=6.0"
 
-        echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
+        JSON_STRING=$( jq -n --arg comment "$MESSAGE"  \
+                  '{comments: [ { content: $comment  } ] }' )
+        echo "try 0"
+        echo curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
+        curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
 
         echo "try 1"
         cmd="curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
         echo $cmd
         eval "$cmd"
-        
-        echo "try 2"
-        echo curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
-        curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
 
-        echo "try 3"
-        echo curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
-        curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
+        # echo "try 1.1"
+        # abcd="{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]} "
+        # curl -X POST $url  -H "Content-Type:application/json" --data "$abcd" -H "Authorization: Basic $encoded_token"
+        
+        # echo "\ntry 2"
+        # echo curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
+        # curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
+
+        # echo "\ntry 3"
+        # data="\"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
+        # echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \\\"$data\\\""
+        # curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data $data
+
+        # echo "\ntry 4"
+        # echo curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
+        # curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
 
         # echo "curl $url -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\\\"description\\\": \\\"$MESSAGE\\\"}\""
         

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -222,12 +222,7 @@ function manifest_diff_into_pr() {
 
         # url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0"
         url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullRequests/$1/threads?api-version=6.0"
-        echo "------------------------------------------------------------"
-        JSON_STRING=$( jq -n --arg comment "$MESSAGE"  \
-                  '{comments: [ { content: $comment  } ] }' )
-        echo "curl -X POST $url  -H \"Content-Type:application/json\" --data \"$JSON_STRING\" -H \"Authorization: Basic $encoded_token\""
-        curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
-        echo "------------------------------------------------------------"
+        
 
         echo "\ntry 2"
         echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
@@ -236,6 +231,13 @@ function manifest_diff_into_pr() {
         echo "\ntry 3"
         echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}\""
         curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
+
+        echo "\n------------------------------------------------------------"
+        JSON_STRING=$( jq -n --arg comment "$MESSAGE"  \
+                  '{comments: [ { content: $comment  } ] }' )
+        echo "curl -X POST $url  -H \"Content-Type:application/json\" --data \"$JSON_STRING\" -H \"Authorization: Basic $encoded_token\""
+        curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
+        echo "\n------------------------------------------------------------"
 
     else
         echo "Manifest generation files will not be modified at all."

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -196,9 +196,9 @@ function manifest_diff_into_pr() {
     if [[ $(git status --porcelain) ]]; then
         echo "The following diff will be applied to cluster-manifests upon merge:" > diff.txt
         # echo "\\\`\\\`\\\`diff" >> diff.txt
-        echo "\\\`\\\`\\\`diff" >> diff.txt
+        echo "\`\`\`diff" >> diff.txt
         git diff | tee -a diff.txt
-        echo "\\\`\\\`\\\`" >> diff.txt
+        echo "\`\`\`" >> diff.txt
         # echo "\\\`\\\`\\\`" >> diff.txt
         # MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
         # description only allows 4000 characters at max
@@ -212,48 +212,20 @@ function manifest_diff_into_pr() {
         HLD_PATH="${HLD_PATH#http://}"
         HLD_PATH="${HLD_PATH#https://}"
         arr=($(echo "$HLD_PATH" | tr '/' '\n'))
-        echo "HLD_PATH=$HLD_PATH"
-        echo "${arr[4]}"
-        echo "${arr[2]}"
-        echo "${arr[1]}"
+        # echo "HLD_PATH=$HLD_PATH"
+        # echo "${arr[4]}"
+        # echo "${arr[2]}"
+        # echo "${arr[1]}"
         # MESSAGE=$(awk '$1=$1' ORS=' \\n ' diff.txt)
         MESSAGE=$(echo ${MESSAGE:0:4000})
         echo $MESSAGE
 
-        # url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullrequests/$1\?api-version\=6.0"
         url="https://dev.azure.com/${arr[1]}/${arr[2]}/_apis/git/repositories/${arr[4]}/pullRequests/$1/threads?api-version=6.0"
 
         JSON_STRING=$( jq -n --arg comment "$MESSAGE"  \
                   '{comments: [ { content: $comment  } ] }' )
-        echo "try 0"
         echo curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
         curl -X POST $url  -H "Content-Type:application/json" --data "$JSON_STRING" -H "Authorization: Basic $encoded_token"
-
-        echo "try 1"
-        cmd="curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
-        echo $cmd
-        eval "$cmd"
-
-        # echo "try 1.1"
-        # abcd="{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]} "
-        # curl -X POST $url  -H "Content-Type:application/json" --data "$abcd" -H "Authorization: Basic $encoded_token"
-        
-        # echo "\ntry 2"
-        # echo curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
-        # curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
-
-        # echo "\ntry 3"
-        # data="\"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
-        # echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \\\"$data\\\""
-        # curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data $data
-
-        # echo "\ntry 4"
-        # echo curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
-        # curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \"comments\": [ { \"content\": \"$MESSAGE\" } ]}"
-
-        # echo "curl $url -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\\\"description\\\": \\\"$MESSAGE\\\"}\""
-        
-        # curl $url -X PATCH -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{\\\"description\\\": \\\"$MESSAGE\\\"}" 
     else
         echo "Manifest generation files will not be modified at all."
         az repos pr update --id $1 --description "Manifest generation files will not be modified at all."

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -144,7 +144,7 @@ function fab_generate() {
     # In the case that all components are removed from the source hld,
     # generated folder should still not be empty
     if find "generated" -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
-        export manifest_files_location=$(pwd)
+        export manifest_files_location=$(pwd)/generated/
         echo "Manifest files have been generated in $manifest_files_location."
     else
         echo "Manifest files could not be generated in 'pwd', quitting..."
@@ -167,7 +167,7 @@ function manifest_diff_into_pr() {
     rm -rf */
 
     if [ -z "$FAB_ENVS" ]; then
-        cp -a $manifest_files_location/. .
+        cp -a $manifest_files_location. .
         ls -al 
     else
         IFS=',' read -ra ENV <<< "$FAB_ENVS"
@@ -306,8 +306,8 @@ function git_commit() {
     echo "GIT REMOVE"
     rm -rf ./*/
     git rm -rf ./*/
-    echo "COPY YAML FILES FROM $manifest_files_location/generated/ TO REPO DIRECTORY..."
-    cp -r "$manifest_files_location/generated/"* .
+    echo "COPY YAML FILES FROM $manifest_files_location TO REPO DIRECTORY..."
+    cp -r "$manifest_files_location"* .
     echo "GIT ADD"
     git add -A
 

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -225,6 +225,9 @@ function manifest_diff_into_pr() {
 
         echo "curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
         
+        cmd="curl -X POST $url -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}\""
+        eval "$cmd"
+        
         curl -X POST $url -H "Authorization: Basic $encoded_token"  -H "Content-Type:application/json" --data "{ \\\"comments\\\": [ { \\\"content\\\": \\\"$MESSAGE\\\" } ]}"
 
         # echo "curl $url -X PATCH -H \"Authorization: Basic $encoded_token\"  -H \"Content-Type:application/json\" --data \"{\\\"description\\\": \\\"$MESSAGE\\\"}\""

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -200,7 +200,7 @@ function manifest_diff_into_pr() {
         git diff | tee -a diff.txt
         echo "\`\`\`" >> diff.txt
         # echo "\\\`\\\`\\\`" >> diff.txt
-        MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
+        # MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
         # description only allows 4000 characters at max
         MESSAGE=$(echo ${MESSAGE:0:4000})
         encoded_token=$(echo -n ':$ACCESS_TOKEN_SECRET' |  base64)

--- a/gitops/azure-devops/build.sh
+++ b/gitops/azure-devops/build.sh
@@ -74,9 +74,9 @@ function download_fab() {
     else
         echo "There was an error when downloading Fabrikate. Please check version number and try again."
     fi
-    filename=$(uuidgen)
-    wget -q -O "$filename.zip" "https://github.com/Microsoft/fabrikate/releases/download/$VERSION_TO_DOWNLOAD/fab-v$VERSION_TO_DOWNLOAD-$os-amd64.zip"
-    unzip "$filename.zip" -d fab
+    filename="$(uuidgen).zip"
+    wget -q -O $filename "https://github.com/Microsoft/fabrikate/releases/download/$VERSION_TO_DOWNLOAD/fab-v$VERSION_TO_DOWNLOAD-$os-amd64.zip"
+    unzip $filename -d fab
 
     export PATH=$PATH:$HOME/fab
 }
@@ -145,7 +145,7 @@ function fab_generate() {
     # generated folder should still not be empty
     if find "generated" -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
         export manifest_files_location=$(pwd)
-        echo "Manifest files have been generated in 'pwd'."
+        echo "Manifest files have been generated in $manifest_files_location."
     else
         echo "Manifest files could not be generated in 'pwd', quitting..."
         exit 1
@@ -162,21 +162,27 @@ function manifest_diff_into_pr() {
     fab_generate
     git_connect
 
+    ls -al 
+    echo "about to replace manifests with new ones"
     rm -rf */
 
     if [ -z "$FAB_ENVS" ]; then
         cp -a $manifest_files_location/. .
+        ls -al 
     else
         IFS=',' read -ra ENV <<< "$FAB_ENVS"
         for i in "${ENV[@]}"
         do
         cp -R ../generated/$i ./
         done
+        
+        ls -al 
     fi
 
     if [[ $(git status --porcelain) ]]; then
         echo "The following diff will be applied to cluster-manifests upon merge:" > diff.txt
         git diff | tee -a diff.txt
+        cat diff.txt
         MESSAGE=$(sed 's/^.\{1,\}$/"&"/' diff.txt)
         echo "az repos pr update --id $1 --description $(echo ${MESSAGE:0:4000})"
 


### PR DESCRIPTION
- Added a helper function to the AzDO script to generate manifests and post a diff as a comment - see [here](https://dev.azure.com/epicstuff/hellobedrock/_git/hello-world-full-stack-hld/pullrequest/4349) for an example
- Fixed a minor bug where downloading fabrikate would get into infinite loop when there's another downloaded archive from a previous job with the same name. Using a random uuid fixes this issue 
- Adding `-q` to silence the wget output which was taking up 90% of the output in logs, making it difficult to focus on the important logs generated by the scripts 

Closes https://github.com/microsoft/spektate/issues/155 